### PR TITLE
Regulations indirect

### DIFF
--- a/Analysis/CTL.py
+++ b/Analysis/CTL.py
@@ -13,11 +13,6 @@ class CTL:
         state_labels, AP_labels = ts.create_AP_labels(APs, include_init=False)
         formula = CTL_formula.replace_APs(AP_labels, extra_quotes=False)
 
-        print(AP_labels)
-
-        for key, value in state_labels.items():
-            print(key, value)
-
         kripke = ts.to_kripke(state_labels)
         parser = Parser()
         formula = parser(str(formula))

--- a/Analysis/CTL.py
+++ b/Analysis/CTL.py
@@ -13,6 +13,11 @@ class CTL:
         state_labels, AP_labels = ts.create_AP_labels(APs, include_init=False)
         formula = CTL_formula.replace_APs(AP_labels, extra_quotes=False)
 
+        print(AP_labels)
+
+        for key, value in state_labels.items():
+            print(key, value)
+
         kripke = ts.to_kripke(state_labels)
         parser = Parser()
         formula = parser(str(formula))

--- a/Core/Rate.py
+++ b/Core/Rate.py
@@ -136,7 +136,7 @@ class Vectorizer(Transformer):
             if complex.compatible(self.ordering[i]):
                 result[i] = 1
 
-        result = TS.State.MemorylessState(result)
+        result = TS.State.VectorState(result)
         self.visited.append(result)
         return Tree("agent", [result])
 

--- a/Core/Reaction.py
+++ b/Core/Reaction.py
@@ -6,7 +6,7 @@ from TS.VectorReaction import VectorReaction
 
 
 class Reaction:
-    def __init__(self, lhs: Side, rhs: Side, rate: Rate):
+    def __init__(self, lhs: Side, rhs: Side, rate: Rate, label=None):
         """
         Class to represent BCSL reaction
 
@@ -17,6 +17,7 @@ class Reaction:
         self.lhs = lhs
         self.rhs = rhs
         self.rate = rate
+        self.label = label
 
     def __eq__(self, other: 'Reaction'):
         return self.lhs == other.lhs and self.rhs == other.rhs and self.rate == other.rate
@@ -25,7 +26,8 @@ class Reaction:
         return str(self)
 
     def __str__(self):
-        return str(self.lhs) + " => " + str(self.rhs) + " @ " + str(self.rate)
+        label = self.label + " ~ " if self.label else ""
+        return label + str(self.lhs) + " => " + str(self.rhs) + " @ " + str(self.rate)
 
     def __lt__(self, other):
         return str(self) < str(other)
@@ -43,7 +45,8 @@ class Reaction:
         """
         return VectorReaction(self.lhs.to_vector(ordering),
                               self.rhs.to_vector(ordering),
-                              self.rate)
+                              self.rate,
+                              self.label)
 
     def compatible(self, other: 'Reaction') -> bool:
         """

--- a/Core/Rule.py
+++ b/Core/Rule.py
@@ -80,7 +80,7 @@ class Rule:
         :return: created Reaction
         """
         lhs, rhs = self.create_complexes()
-        return Reaction(lhs, rhs, copy(self.rate))
+        return Reaction(lhs, rhs, copy(self.rate), self.label)
 
     def rate_to_vector(self, ordering, definitions: dict):
         """
@@ -116,7 +116,7 @@ class Rule:
         reactions = set()
         for result in itertools.product(*results):
             new_agents = tuple(filter(None, column(result, 0) + column(result, 1)))
-            new_rule = Rule(new_agents, self.mid, self.compartments, self.complexes, self.pairs, self.rate)
+            new_rule = Rule(new_agents, self.mid, self.compartments, self.complexes, self.pairs, self.rate, self.label)
             reactions.add(new_rule.to_reaction())
         return reactions
 

--- a/Core/Side.py
+++ b/Core/Side.py
@@ -3,7 +3,7 @@ import numpy as np
 from sortedcontainers import SortedList
 
 from Core.Complex import Complex
-from TS.State import MemorylessState
+from TS.State import VectorState
 
 
 class Side:
@@ -44,18 +44,18 @@ class Side:
             return self.to_counter().most_common(1)[0][1]
         return 0
 
-    def to_vector(self, ordering: SortedList) -> MemorylessState:
+    def to_vector(self, ordering: SortedList) -> VectorState:
         """
-        Convert the Side to a MemorylessState accoring to given ordering.
+        Convert the Side to a VectorState according to given ordering.
 
         :param ordering: sequence of complex agents
-        :return: MemorylessState representing vector
+        :return: VectorState representing vector
         """
         vector = np.zeros(len(ordering), dtype=int)
         multiset = self.to_counter()
         for agent in list(multiset):
             vector[ordering.index(agent)] = multiset[agent]
-        return MemorylessState(vector)
+        return VectorState(vector)
 
     def compatible(self, other: 'Side') -> bool:
         """

--- a/Parsing/ParseBCSL.py
+++ b/Parsing/ParseBCSL.py
@@ -20,7 +20,7 @@ from Regulations.Conditional import Conditional
 from Regulations.Ordered import Ordered
 from Regulations.Programmed import Programmed
 from Regulations.Regular import Regular
-from TS.State import MemorylessState
+from TS.State import VectorState
 from TS.TransitionSystem import TransitionSystem
 from TS.Edge import edge_from_dict
 from Core.Side import Side
@@ -39,14 +39,14 @@ def load_TS_from_json(json_file: str) -> TransitionSystem:
 
         ordering = SortedList(map(lambda agent: complex_parser.parse(agent).data.children[0], data['ordering']))
         ts = TransitionSystem(ordering, data['bound'])
-        ts.states_encoding = {MemorylessState(np.array(eval(data['nodes'][node_id]))): int(node_id)
+        ts.states_encoding = {VectorState(np.array(eval(data['nodes'][node_id]))): int(node_id)
                               for node_id in data['nodes']}
         ts.edges = {edge_from_dict(edge) for edge in data['edges']}
         ts.init = data['initial']
         if 'parameters' in data:
             ts.params = data['parameters']
 
-        ts.unprocessed = {MemorylessState(np.array(eval(state))) for state in data.get('unprocessed', list())}
+        ts.unprocessed = {VectorState(np.array(eval(state))) for state in data.get('unprocessed', list())}
         ts.processed = ts.states_encoding.keys() - ts.unprocessed
         return ts
 

--- a/Parsing/ParseBCSL.py
+++ b/Parsing/ParseBCSL.py
@@ -423,11 +423,13 @@ class TreeToObjects(Transformer):
             pairs += [(i, None) for i in range(rhs.counter, lhs.counter)]
         elif lhs.counter < rhs.counter:
             for i in range(lhs.counter, rhs.counter):
-                if lhs.counter != 0:  # make sure lhs is not empty
-                    if lhs.seq[pairs[-1][0]] == rhs.seq[pairs[-1][1]]:
-                        if rhs.seq[pairs[-1][1]] == rhs.seq[i + lhs.counter - 1]:
+                replication = False
+                if lhs.counter == 1 and rhs.counter > 1:
+                    if lhs.seq[pairs[-1][0]] == rhs.seq[pairs[-1][1] - lhs.counter]:
+                        if rhs.seq[pairs[-1][1] - lhs.counter] == rhs.seq[i]:
                             pairs += [(pairs[-1][0], i + lhs.counter)]
-                else:
+                            replication = True
+                if not replication:
                     pairs += [(None, i + lhs.counter)]
 
         return Rule(agents, mid, compartments, complexes, pairs, Rate(rate) if rate else None, label)
@@ -532,18 +534,18 @@ class Parser:
         :param tree: given parsed Tree
         :return: Result containing constructed BCSL object
         """
-        try:
-            complexer = ExtractComplexNames()
-            tree = complexer.transform(tree)
-            de_abstracter = TransformAbstractSyntax(complexer.complex_defns)
-            tree = de_abstracter.transform(tree)
-            tree = TreeToComplex().transform(tree)
-            tree = TransformRegulations().transform(tree)
-            tree = TreeToObjects().transform(tree)
+        # try:
+        complexer = ExtractComplexNames()
+        tree = complexer.transform(tree)
+        de_abstracter = TransformAbstractSyntax(complexer.complex_defns)
+        tree = de_abstracter.transform(tree)
+        tree = TreeToComplex().transform(tree)
+        tree = TransformRegulations().transform(tree)
+        tree = TreeToObjects().transform(tree)
 
-            return Result(True, tree.children[0])
-        except Exception as u:
-            return Result(False, {"error": str(u)})
+        return Result(True, tree.children[0])
+        # except Exception as u:
+        #     return Result(False, {"error": str(u)})
 
     def syntax_check(self, expression: str) -> Result:
         """

--- a/Parsing/ParseBCSL.py
+++ b/Parsing/ParseBCSL.py
@@ -422,7 +422,12 @@ class TreeToObjects(Transformer):
         if lhs.counter > rhs.counter:
             pairs += [(i, None) for i in range(rhs.counter, lhs.counter)]
         elif lhs.counter < rhs.counter:
-            pairs += [(None, i + lhs.counter) for i in range(lhs.counter, rhs.counter)]
+            for i in range(lhs.counter, rhs.counter):
+                if lhs.seq[pairs[-1][0]] == rhs.seq[pairs[-1][1]]:
+                    if rhs.seq[pairs[-1][1]] == rhs.seq[i + lhs.counter - 1]:
+                        pairs += [(pairs[-1][0], i + lhs.counter)]
+                else:
+                    pairs += [(None, i + lhs.counter)]
 
         return Rule(agents, mid, compartments, complexes, pairs, Rate(rate) if rate else None, label)
 

--- a/Parsing/ParseBCSL.py
+++ b/Parsing/ParseBCSL.py
@@ -423,9 +423,10 @@ class TreeToObjects(Transformer):
             pairs += [(i, None) for i in range(rhs.counter, lhs.counter)]
         elif lhs.counter < rhs.counter:
             for i in range(lhs.counter, rhs.counter):
-                if lhs.seq[pairs[-1][0]] == rhs.seq[pairs[-1][1]]:
-                    if rhs.seq[pairs[-1][1]] == rhs.seq[i + lhs.counter - 1]:
-                        pairs += [(pairs[-1][0], i + lhs.counter)]
+                if lhs.counter != 0:  # make sure lhs is not empty
+                    if lhs.seq[pairs[-1][0]] == rhs.seq[pairs[-1][1]]:
+                        if rhs.seq[pairs[-1][1]] == rhs.seq[i + lhs.counter - 1]:
+                            pairs += [(pairs[-1][0], i + lhs.counter)]
                 else:
                     pairs += [(None, i + lhs.counter)]
 

--- a/Regulations/Conditional.py
+++ b/Regulations/Conditional.py
@@ -24,3 +24,18 @@ class Conditional(BaseRegulation):
         if label not in self.regulation:
             return False
         return self.regulation[label] & agents
+
+
+class VectorConditional(Conditional):
+    def __init__(self, regulation):
+        super().__init__(regulation)
+        self.memory = 0
+
+    def filter(self, current_state, candidates):
+        seq = current_state
+        return {rule: values for rule, values in candidates.items() if not self.check_intersection(rule.label, seq)}
+
+    def check_intersection(self, label, agents):
+        if label not in self.regulation:
+            return False
+        return self.regulation[label].check_intersection(agents)

--- a/TS/DirectTS.py
+++ b/TS/DirectTS.py
@@ -1,6 +1,8 @@
 from sortedcontainers import SortedList
 import json
 
+from TS.TransitionSystem import TransitionSystem
+
 
 class DirectTS:
     def __init__(self):
@@ -18,6 +20,10 @@ class DirectTS:
         return str(self)
 
     def save_to_json(self, output_file, params=None):
+        ts = self.to_vector_ts()
+        ts.save_to_json(output_file, params)
+
+    def to_vector_ts(self):
         ordering = SortedList(sorted(self.unique_complexes))
         # state -> unique ID
         states_encoding = self.create_encoding()
@@ -27,15 +33,19 @@ class DirectTS:
         states = dict()
         for state in states_encoding:
             # unique ID -> numpy vector
-            states[states_encoding[state]] = str(state.to_vector(ordering))
+            states[state.to_vector(ordering)] = states_encoding[state]
 
         unprocessed = dict()
         if self.unprocessed:
             for state in self.unprocessed:
-                unprocessed[states_encoding[state]] = str(state.to_vector(ordering))
+                unprocessed[state.to_vector(ordering)] = states_encoding[state]
 
-        init = states_encoding[self.init]
-        save_to_json(states, unprocessed, self.edges, init, ordering, output_file, self.bound, params)
+        ts = TransitionSystem(ordering, self.bound)
+        ts.states_encoding = states
+        ts.edges = self.edges
+        ts.init = states_encoding[self.init]
+        ts.unprocessed = unprocessed
+        return ts
 
     def create_encoding(self):
         # for now assume generating is complete i.e. ignore unprocessed states
@@ -47,22 +57,3 @@ class DirectTS:
     def encode_edges(self, states_encoding):
         for edge in self.edges:
             edge.encode(states_encoding)
-
-
-def save_to_json(states, unprocessed, edges, init, ordering, output_file, bound, params):
-    """
-    Save current TS as a JSON file.
-
-    :param output_file: given file to write to
-    """
-    unique = list(map(str, ordering))
-    edges = [edge.to_dict() for edge in edges]
-    data = {'nodes': states, 'edges': edges, 'ordering': unique, 'initial': init, 'bound': bound}
-    if params:
-        data['parameters'] = list(params)
-
-    if unprocessed:
-        data['unprocessed'] = unprocessed
-
-    with open(output_file, 'w') as json_file:
-        json.dump(data, json_file, indent=4)

--- a/TS/Edge.py
+++ b/TS/Edge.py
@@ -7,7 +7,7 @@ class Edge:
         self._is_encoded = encoded
 
     def __hash__(self):
-        return hash((self.source, self.target, self.probability))
+        return hash((self.source, self.target, truncate(self.probability, 5)))
 
     def __eq__(self, other: 'Edge'):
         return self.source == other.source and self.target == other.target and self.probability == other.probability
@@ -38,9 +38,24 @@ class Edge:
         :param encoding_new: the new encoding
         :return: new Edge in new encoding
         """
-        return Edge(encoding_new[encoding_old[self.source]],
-                    encoding_new[encoding_old[self.target]],
-                    self.probability)
+        source_code = None
+        target_code = None
+
+        for state, code in encoding_new.items():
+            if state == encoding_old[self.source]:
+                source_code = code
+            if state == encoding_old[self.target]:
+                target_code = code
+
+        if source_code and target_code:
+            return Edge(source_code, target_code, self.probability)
+        else:
+            raise KeyError
+
+        # dicts with OneStepMemoryVectorState are not working
+        # return Edge(encoding_new[encoding_old[self.source]],
+        #             encoding_new[encoding_old[self.target]],
+        #             self.probability)
 
     def add_rate(self, rate):
         """
@@ -99,3 +114,7 @@ def edge_from_dict(d: dict) -> Edge:
     """
     label = d.get('label', None)
     return Edge(d['s'], d['t'], d['p'], label, encoded=True)
+
+
+def truncate(f, n):
+    return float(int(f * 10 ** n)) / (10 ** n)

--- a/TS/Edge.py
+++ b/TS/Edge.py
@@ -7,7 +7,8 @@ class Edge:
         self._is_encoded = encoded
 
     def __hash__(self):
-        return hash((self.source, self.target, truncate(self.probability, 5)))
+        prob = truncate(self.probability, 5) if type(self.probability) == float else self.probability
+        return hash((self.source, self.target, prob))
 
     def __eq__(self, other: 'Edge'):
         return self.source == other.source and self.target == other.target and self.probability == other.probability
@@ -47,7 +48,7 @@ class Edge:
             if state == encoding_old[self.target]:
                 target_code = code
 
-        if source_code and target_code:
+        if source_code is not None and target_code is not None:
             return Edge(source_code, target_code, self.probability)
         else:
             raise KeyError

--- a/TS/TransitionSystem.py
+++ b/TS/TransitionSystem.py
@@ -80,7 +80,8 @@ class TransitionSystem:
             if state not in self.states_encoding:
                 self.states_encoding[state] = len(self.states_encoding) + 1
 
-        self.init = self.states_encoding[self.init]
+        if type(self.init) != int:
+            self.init = self.states_encoding[self.init]
         self.processed = set()
         self.encode_edges()
 
@@ -270,13 +271,17 @@ class TransitionSystem:
 
         ordering = copy(self.ordering)
 
+        to_remove = []
         for i in range(len(check)):
             if check[i] == 0:
-                for state, code in self.states_encoding.items():
-                    new_sequence = np.delete(state.sequence, i)
-                    state.sequence = new_sequence
+                to_remove.append(i)
 
-                del ordering[i]
+        for state, code in self.states_encoding.items():
+            new_sequence = np.delete(state.sequence, to_remove)
+            state.sequence = new_sequence
+
+        for i in reversed(to_remove):
+            del ordering[i]
 
         new_ts = TransitionSystem(ordering, self.bound)
         new_ts.init = self.init

--- a/TS/TransitionSystem.py
+++ b/TS/TransitionSystem.py
@@ -4,14 +4,14 @@ from itertools import groupby
 from sortedcontainers import SortedList
 from pyModelChecking import Kripke
 
-from TS.State import MemorylessState
+from TS.State import VectorState
 
 
 class TransitionSystem:
     def __init__(self, ordering: SortedList, bound):
-        self.states_encoding = dict()  # MemorylessState -> int
+        self.states_encoding = dict()  # VectorState -> int
         self.edges = set()  # Edge objects: (int from, int to, probability), can be used for explicit Storm format
-        self.ordering = ordering  # used to decode MemorylessState to actual agents
+        self.ordering = ordering  # used to decode VectorState to actual agents
         self.init = int
         self.params = []
         self.bound = bound
@@ -66,9 +66,9 @@ class TransitionSystem:
         return set(map(hash, ts.edges)) == set(map(hash, other.edges))
         # return ts.edges == other.edges
 
-    def encode(self, init: MemorylessState):
+    def encode(self, init: VectorState):
         """
-        Assigns a unique code to each MemorylessState for storing purposes
+        Assigns a unique code to each VectorState for storing purposes
         """
         for state in self.processed | self.unprocessed:
             if state not in self.states_encoding:
@@ -80,7 +80,7 @@ class TransitionSystem:
 
     def encode_edges(self):
         """
-        Encodes every MemorylessState in Edge according to the unique encoding.
+        Encodes every VectorState in Edge according to the unique encoding.
         """
         for edge in self.edges:
             edge.encode(self.states_encoding)
@@ -136,7 +136,7 @@ class TransitionSystem:
         for key, value in self.states_encoding.items():
             if key.is_inf:
                 del self.states_encoding[key]
-                hell = MemorylessState(np.array([self.bound + 1] * len(key)))
+                hell = VectorState(np.array([self.bound + 1] * len(key)))
                 hell.is_inf = True
                 self.states_encoding[hell] = value
                 break

--- a/TS/VectorModel.py
+++ b/TS/VectorModel.py
@@ -222,6 +222,6 @@ class VectorModel:
         while any([worker.is_alive() for worker in workers]):
             time.sleep(1)
 
-        ts.encode(self.init)
+        ts.encode()
 
         return ts

--- a/TS/VectorModel.py
+++ b/TS/VectorModel.py
@@ -7,7 +7,7 @@ import pandas as pd
 import random
 from sortedcontainers import SortedList
 
-from TS.State import MemorylessState
+from TS.State import VectorState, FullMemoryVectorState, OneStepMemoryVectorState
 from TS.TSworker import TSworker
 from TS.TransitionSystem import TransitionSystem
 
@@ -34,11 +34,12 @@ def handle_number_of_threads(number, workers):
 
 
 class VectorModel:
-    def __init__(self, vector_reactions: set, init: MemorylessState, ordering: SortedList, bound: int):
+    def __init__(self, vector_reactions: set, init: VectorState, ordering: SortedList, bound: int, regulation=None):
         self.vector_reactions = vector_reactions
         self.init = init
         self.ordering = ordering
         self.bound = bound if bound else self.compute_bound()
+        self.regulation = regulation
 
     def __eq__(self, other: 'VectorModel') -> bool:
         return self.vector_reactions == other.vector_reactions and \
@@ -106,7 +107,7 @@ class VectorModel:
         Gillespie algorithm implementation.
 
         Each step a random reaction is chosen by exponential distribution with density given as a sum
-        of all possible rates in particular MemorylessState.
+        of all possible rates in particular VectorState.
         Then such reaction is applied and next time is computed using Poisson distribution (random.expovariate).
 
         :param max_time: time when simulation ends
@@ -185,7 +186,17 @@ class VectorModel:
         """
         if not ts:
             ts = TransitionSystem(self.ordering, self.bound)
-            ts.unprocessed = {self.init}
+            if self.regulation:
+                if self.regulation.memory == 0:
+                    ts.init = VectorState(self.init.sequence)
+                elif self.regulation.memory == 1:
+                    ts.init = OneStepMemoryVectorState(self.init.sequence)
+                else:
+                    ts.init = FullMemoryVectorState(self.init.sequence)
+            else:
+                ts.init = VectorState(self.init.sequence)
+
+            ts.unprocessed = {ts.init}
 
         workers = [TSworker(ts, self) for _ in range(multiprocessing.cpu_count())]
         for worker in workers:

--- a/TS/VectorReaction.py
+++ b/TS/VectorReaction.py
@@ -1,15 +1,17 @@
 from Core.Rate import Rate
-from TS.State import MemorylessState
+from TS.State import VectorState
 
 
 class VectorReaction:
-    def __init__(self, source: MemorylessState, target: MemorylessState, rate: Rate):
+    def __init__(self, source: VectorState, target: VectorState, rate: Rate, label=None):
         self.source = source
         self.target = target
         self.rate = rate
+        self.label = label
 
     def __str__(self):
-        return str(self.source) + " -> " + str(self.target) + " @ " + str(self.rate)
+        label = self.label + " ~ " if self.label else ""
+        return label + str(self.source) + " -> " + str(self.target) + " @ " + str(self.rate)
 
     def __eq__(self, other: 'VectorReaction'):
         return self.source == other.source and self.target == other.target and self.rate == other.rate
@@ -23,16 +25,16 @@ class VectorReaction:
     def __hash__(self):
         return hash(str(self))
 
-    def apply(self, state: MemorylessState, bound: float):
+    def apply(self, state: VectorState, bound: float):
         """
-        Applies the reaction on a given MemorylessState.
-        First, source is subtracted from the given MemorylessState, then it is checked if all
-        values are greater then 0. If so, new MemorylessState is create as sum with target
+        Applies the reaction on a given VectorState.
+        First, source is subtracted from the given VectorState, then it is checked if all
+        values are greater then 0. If so, new VectorState is create as sum with target
         and rate is evaluated. Moreover, it is possible that the resulting state is greater
-        than allowed bound, then infinite MemorylessState is returned instead.
-        :param state: given MemorylessState
+        than allowed bound, then infinite VectorState is returned instead.
+        :param state: given VectorState
         :param bound: allow bound on particular values
-        :return: new MemorylessState and evaluated rate
+        :return: new VectorState and evaluated rate
         """
         if state >= self.source:
             new_state = state - self.source

--- a/Testing/test_TS.py
+++ b/Testing/test_TS.py
@@ -4,7 +4,7 @@ import numpy as np
 from Core.Complex import Complex
 from Core.Structure import StructureAgent
 from TS.Edge import Edge
-from TS.State import MemorylessState
+from TS.State import VectorState
 from TS.TransitionSystem import TransitionSystem
 
 
@@ -24,16 +24,16 @@ class TestTransitionSystem(unittest.TestCase):
         ordering_wrong = (self.c1, self.c2, self.c3, self.c4),
         ordering_reordered = (self.c3, self.c1, self.c2)
 
-        self.s1 = MemorylessState(np.array((1, 2, 3)))
-        self.s2 = MemorylessState(np.array((1, 2, 4)))
-        self.s3 = MemorylessState(np.array((1, 2, 5)))
-        self.s4 = MemorylessState(np.array((4, 2, 3)))
-        self.hell = MemorylessState(np.array((np.inf, np.inf, np.inf)))
+        self.s1 = VectorState(np.array((1, 2, 3)))
+        self.s2 = VectorState(np.array((1, 2, 4)))
+        self.s3 = VectorState(np.array((1, 2, 5)))
+        self.s4 = VectorState(np.array((4, 2, 3)))
+        self.hell = VectorState(np.array((np.inf, np.inf, np.inf)))
         self.hell.is_inf = True
 
-        self.s1_reordered = MemorylessState(np.array((3, 1, 2)))
-        self.s2_reordered = MemorylessState(np.array((4, 1, 2)))
-        self.s3_reordered = MemorylessState(np.array((5, 1, 2)))
+        self.s1_reordered = VectorState(np.array((3, 1, 2)))
+        self.s2_reordered = VectorState(np.array((4, 1, 2)))
+        self.s3_reordered = VectorState(np.array((5, 1, 2)))
 
         self.ts = TransitionSystem(tuple(), 5)
         self.ts.states_encoding = {self.s1: 1, self.s2: 2}
@@ -116,6 +116,6 @@ class TestTransitionSystem(unittest.TestCase):
         ts = TransitionSystem(ordering, 4)
         ts.states_encoding = {self.s1: 1, self.s2: 2, self.s3: 0, self.hell: 3}
         ts.change_hell()
-        new_hell = MemorylessState(np.array([5, 5, 5]))
+        new_hell = VectorState(np.array([5, 5, 5]))
         new_encoding = {self.s1: 1, self.s2: 2, self.s3: 0, new_hell: 3}
         self.assertEqual(ts.states_encoding, new_encoding)

--- a/Testing/test_formal_methods_files.py
+++ b/Testing/test_formal_methods_files.py
@@ -10,7 +10,7 @@ from TS.TransitionSystem import TransitionSystem
 from Core.Structure import StructureAgent
 from Core.Complex import Complex
 from Parsing.ParseBCSL import Parser
-from TS.State import MemorylessState
+from TS.State import VectorState
 
 
 def get_storm_result(cmd: str):
@@ -41,19 +41,19 @@ class TestFormalMethods(unittest.TestCase):
 
         ordering = (self.c1, self.c2)
 
-        self.s1 = MemorylessState(np.array((0, 0)))
-        self.s2 = MemorylessState(np.array((1, 0)))
-        self.s3 = MemorylessState(np.array((2, 0)))
-        self.s4 = MemorylessState(np.array((3, 0)))
-        self.s5 = MemorylessState(np.array((4, 0)))
-        self.s6 = MemorylessState(np.array((5, 0)))
-        self.s7 = MemorylessState(np.array((6, 0)))
-        self.s8 = MemorylessState(np.array((7, 1)))
-        self.s9 = MemorylessState(np.array((7, 2)))
-        self.s10 = MemorylessState(np.array((7, 3)))
-        self.s11 = MemorylessState(np.array((7, 4)))
-        self.s12 = MemorylessState(np.array((7, 5)))
-        self.s13 = MemorylessState(np.array((7, 6)))
+        self.s1 = VectorState(np.array((0, 0)))
+        self.s2 = VectorState(np.array((1, 0)))
+        self.s3 = VectorState(np.array((2, 0)))
+        self.s4 = VectorState(np.array((3, 0)))
+        self.s5 = VectorState(np.array((4, 0)))
+        self.s6 = VectorState(np.array((5, 0)))
+        self.s7 = VectorState(np.array((6, 0)))
+        self.s8 = VectorState(np.array((7, 1)))
+        self.s9 = VectorState(np.array((7, 2)))
+        self.s10 = VectorState(np.array((7, 3)))
+        self.s11 = VectorState(np.array((7, 4)))
+        self.s12 = VectorState(np.array((7, 5)))
+        self.s13 = VectorState(np.array((7, 6)))
 
         self.die_ts = TransitionSystem(ordering, 6)
         self.die_ts.init = 0

--- a/Testing/test_model.py
+++ b/Testing/test_model.py
@@ -12,7 +12,7 @@ from Core.Structure import StructureAgent
 from Core.Complex import Complex
 from Core.Rule import Rule
 from Parsing.ParseBCSL import Parser
-from TS.State import MemorylessState
+from TS.State import VectorState
 import TS.TransitionSystem
 from TS.VectorModel import VectorModel
 from TS.VectorReaction import VectorReaction
@@ -117,11 +117,11 @@ class TestModel(unittest.TestCase):
 
         rate_3 = Rate(Tree('rate', [Tree('fun', [1.0])]))
 
-        init = MemorylessState(np.array([2, 1, 0]))
+        init = VectorState(np.array([2, 1, 0]))
 
-        vector_reactions = {VectorReaction(MemorylessState(np.array([0, 0, 0])), MemorylessState(np.array([0, 1, 0])), rate_1),
-                            VectorReaction(MemorylessState(np.array([1, 0, 0])), MemorylessState(np.array([0, 0, 0])), rate_2),
-                            VectorReaction(MemorylessState(np.array([0, 0, 1])), MemorylessState(np.array([1, 0, 0])), rate_3)}
+        vector_reactions = {VectorReaction(VectorState(np.array([0, 0, 0])), VectorState(np.array([0, 1, 0])), rate_1),
+                            VectorReaction(VectorState(np.array([1, 0, 0])), VectorState(np.array([0, 0, 0])), rate_2),
+                            VectorReaction(VectorState(np.array([0, 0, 1])), VectorState(np.array([1, 0, 0])), rate_3)}
 
         self.vm_1 = VectorModel(vector_reactions, init, ordering, None)
 
@@ -560,10 +560,10 @@ class TestModel(unittest.TestCase):
         APs = [Core.Formula.AtomicProposition(complex_abstract, " >= ", "3"),
                Core.Formula.AtomicProposition(complex_1, " < ", 2)]
 
-        s1 = MemorylessState(np.array((1, 2, 2)))
-        s2 = MemorylessState(np.array((5, 1, 1)))
-        s3 = MemorylessState(np.array((2, 4, 3)))
-        s4 = MemorylessState(np.array((1, 4, 3)))
+        s1 = VectorState(np.array((1, 2, 2)))
+        s2 = VectorState(np.array((5, 1, 1)))
+        s3 = VectorState(np.array((2, 4, 3)))
+        s4 = VectorState(np.array((1, 4, 3)))
 
         states_encoding = {s1: 1, s2: 2, s3: 3, s4: 4}
 

--- a/Testing/test_rate.py
+++ b/Testing/test_rate.py
@@ -7,7 +7,7 @@ from Core.Complex import Complex
 import Core.Rate
 from Core.Structure import StructureAgent
 from Parsing.ParseBCSL import Parser
-from TS.State import MemorylessState
+from TS.State import VectorState
 
 
 class TestRate(unittest.TestCase):
@@ -51,8 +51,8 @@ class TestRate(unittest.TestCase):
 
         # states
 
-        self.state_1 = MemorylessState(np.array([2, 3]))
-        self.state_2 = MemorylessState(np.array([2, 0, 3, 1, 6, 2]))
+        self.state_1 = VectorState(np.array([2, 3]))
+        self.state_2 = VectorState(np.array([2, 0, 3, 1, 6, 2]))
 
     def test_to_str(self):
         self.assertEqual(str(self.rate_1), "3.0*[K()::cyt]/2.0*v_1")
@@ -63,10 +63,10 @@ class TestRate(unittest.TestCase):
 
     def test_vectorize(self):
         ordering = (self.c2, self.c3)
-        self.assertEqual(self.rate_1.vectorize(ordering, dict()), [MemorylessState(np.array([1, 1]))])
+        self.assertEqual(self.rate_1.vectorize(ordering, dict()), [VectorState(np.array([1, 1]))])
         ordering = (self.c2, self.c3, self.c4, self.c5, self.c6, self.c7)
-        self.assertEqual(self.rate_2.vectorize(ordering, dict()), [MemorylessState(np.array([0, 0, 1, 1, 0, 0])),
-                                                                   MemorylessState(np.array([1, 1, 0, 0, 0, 0]))])
+        self.assertEqual(self.rate_2.vectorize(ordering, dict()), [VectorState(np.array([0, 0, 1, 1, 0, 0])),
+                                                                   VectorState(np.array([1, 1, 0, 0, 0, 0]))])
 
     def test_evaluate(self):
         ordering = (self.c2, self.c3)

--- a/Testing/test_regulations.py
+++ b/Testing/test_regulations.py
@@ -33,8 +33,13 @@ class TestRegulations(unittest.TestCase):
         """
         model = self.model_parser.parse(self.model_with_labels + regulation).data
 
-        ts = model.generate_direct_transition_system()
-        ts.save_to_json("Testing/regulations/programmed_ts.json")
+        direct_ts = model.generate_direct_transition_system()
+        direct_ts = direct_ts.to_vector_ts()
+
+        vm = model.to_vector_model()
+        indirect_ts = vm.generate_transition_system()
+
+        self.assertEqual(direct_ts, indirect_ts)
 
     def test_ordered(self):
         regulation = """
@@ -46,8 +51,13 @@ class TestRegulations(unittest.TestCase):
 
         model = self.model_parser.parse(self.model_with_labels + regulation).data
 
-        ts = model.generate_direct_transition_system()
-        ts.save_to_json("Testing/regulations/ordered_ts.json")
+        direct_ts = model.generate_direct_transition_system()
+        direct_ts = direct_ts.to_vector_ts()
+
+        vm = model.to_vector_model()
+        indirect_ts = vm.generate_transition_system()
+
+        self.assertEqual(direct_ts, indirect_ts)
 
     def test_conditional(self):
         regulation = """
@@ -59,8 +69,13 @@ class TestRegulations(unittest.TestCase):
 
         model = self.model_parser.parse(self.model_with_labels + regulation).data
 
-        ts = model.generate_direct_transition_system()
-        ts.save_to_json("Testing/regulations/conditional_ts.json")
+        direct_ts = model.generate_direct_transition_system()
+        direct_ts = direct_ts.to_vector_ts()
+
+        vm = model.to_vector_model()
+        indirect_ts = vm.generate_transition_system()
+
+        self.assertEqual(direct_ts, indirect_ts)
 
     def test_concurrent_free(self):
         regulation = """
@@ -72,8 +87,13 @@ class TestRegulations(unittest.TestCase):
 
         model = self.model_parser.parse(self.model_with_labels + regulation).data
 
-        ts = model.generate_direct_transition_system()
-        ts.save_to_json("Testing/regulations/concurrent_free_ts.json")
+        direct_ts = model.generate_direct_transition_system()
+        direct_ts = direct_ts.to_vector_ts()
+
+        vm = model.to_vector_model()
+        indirect_ts = vm.generate_transition_system()
+
+        self.assertEqual(direct_ts, indirect_ts)
 
     def test_regular(self):
         regulation = """
@@ -85,13 +105,24 @@ class TestRegulations(unittest.TestCase):
 
         model = self.model_parser.parse(self.model_with_labels + regulation).data
 
-        ts = model.generate_direct_transition_system()
-        ts.save_to_json("Testing/regulations/regular_ts.json")
+        direct_ts = model.generate_direct_transition_system()
+        direct_ts = direct_ts.to_vector_ts()
+
+        vm = model.to_vector_model()
+        indirect_ts = vm.generate_transition_system()
+
+        self.assertEqual(direct_ts, indirect_ts)
 
     def test_no_regulation(self):
         model = self.model_parser.parse(self.model_with_labels).data
-        ts = model.generate_direct_transition_system()
-        ts.save_to_json("Testing/regulations/no_regulation_ts.json")
+
+        direct_ts = model.generate_direct_transition_system()
+        direct_ts = direct_ts.to_vector_ts()
+
+        vm = model.to_vector_model()
+        indirect_ts = vm.generate_transition_system()
+
+        self.assertEqual(direct_ts, indirect_ts)
 
     def test_network_free_simulation_regulated(self):
         regulation = """

--- a/Testing/test_rule.py
+++ b/Testing/test_rule.py
@@ -241,6 +241,36 @@ class TestRule(unittest.TestCase):
 
         self.assertEqual(rule1.reduce_context(), rule2)
 
+        # next case
+
+        rule_expr_1 = "K(S{u})::cyt => K(S{p})::cyt + D(B{_})::cell @ 3*[K(S{u})::cyt]/2*v_1"
+        rule1 = self.parser.parse(rule_expr_1).data
+
+        rule_expr_2 = "K()::cyt => K()::cyt + D()::cell @ 3*[K()::cyt]/2*v_1"
+        rule2 = self.parser.parse(rule_expr_2).data
+
+        self.assertEqual(rule1.reduce_context(), rule2)
+
+        # next case - covering replication
+
+        rule_expr_1 = "K(S{u})::cyt => 2 K(S{u})::cyt @ 3*[K(S{u})::cyt]/2*v_1"
+        rule1 = self.parser.parse(rule_expr_1).data
+
+        rule_expr_2 = "K()::cyt => 2 K()::cyt @ 3*[K()::cyt]/2*v_1"
+        rule2 = self.parser.parse(rule_expr_2).data
+
+        self.assertEqual(rule1.reduce_context(), rule2)
+
+        # next case - covering replication
+
+        rule_expr_1 = "K(S{u})::cyt => 3 K(S{u})::cyt @ 3*[K(S{u})::cyt]/2*v_1"
+        rule1 = self.parser.parse(rule_expr_1).data
+
+        rule_expr_2 = "K()::cyt => 3 K()::cyt @ 3*[K()::cyt]/2*v_1"
+        rule2 = self.parser.parse(rule_expr_2).data
+
+        self.assertEqual(rule1.reduce_context(), rule2)
+
     def test_exists_compatible_agent(self):
         complex_parser = Parser("rate_complex")
         agent = "K(S{a}).A{a}::cyt"

--- a/Testing/test_side.py
+++ b/Testing/test_side.py
@@ -6,7 +6,7 @@ from Core.Structure import StructureAgent
 from Core.Atomic import AtomicAgent
 from Core.Complex import Complex
 from Core.Side import Side
-from TS.State import MemorylessState
+from TS.State import VectorState
 import Parsing.ParseBCSL
 
 
@@ -51,7 +51,7 @@ class TestSide(unittest.TestCase):
 
     def test_to_vector(self):
         ordering = (self.c1, self.c2, self.c3, self.c4)
-        self.assertEqual(self.side2.to_vector(ordering), MemorylessState(np.array((0, 1, 1, 1))))
+        self.assertEqual(self.side2.to_vector(ordering), VectorState(np.array((0, 1, 1, 1))))
 
     def test_compatible(self):
         self.assertTrue(self.side5.compatible(self.side4))

--- a/Testing/test_state.py
+++ b/Testing/test_state.py
@@ -3,18 +3,18 @@ import numpy as np
 
 import Parsing.ParseBCSL
 from Core.Formula import AtomicProposition
-from TS.State import MemorylessState
+from TS.State import VectorState
 
 
 class TestState(unittest.TestCase):
     def setUp(self):
-        self.s1 = MemorylessState(np.array((1, 2, 3)))
-        self.s2 = MemorylessState(np.array((5, 4, 3)))
-        self.s3 = MemorylessState(np.array((5, 4, 3, 2)))
-        self.s4 = MemorylessState(np.array((2, 2, 2, 1)))
-        self.s5 = MemorylessState(np.array((7, 6, 5, 3)))
-        self.s6 = MemorylessState(np.array((1, 0, 0, 1, 0)))
-        self.s_inf = MemorylessState(np.array((np.inf, np.inf, np.inf)))
+        self.s1 = VectorState(np.array((1, 2, 3)))
+        self.s2 = VectorState(np.array((5, 4, 3)))
+        self.s3 = VectorState(np.array((5, 4, 3, 2)))
+        self.s4 = VectorState(np.array((2, 2, 2, 1)))
+        self.s5 = VectorState(np.array((7, 6, 5, 3)))
+        self.s6 = VectorState(np.array((1, 0, 0, 1, 0)))
+        self.s_inf = VectorState(np.array((np.inf, np.inf, np.inf)))
 
         complex_parser = Parsing.ParseBCSL.Parser("rate_complex")
 
@@ -23,8 +23,8 @@ class TestState(unittest.TestCase):
         self.complex_3 = complex_parser.parse("K(S{a},T{i}).B{o}::cyt").data.children[0]
 
     def test_sub(self):
-        self.assertEqual(self.s1 - self.s2, MemorylessState(np.array((-4, -2, 0))))
-        self.assertEqual(self.s3 - self.s4, MemorylessState(np.array((3, 2, 1, 1))))
+        self.assertEqual(self.s1 - self.s2, VectorState(np.array((-4, -2, 0))))
+        self.assertEqual(self.s3 - self.s4, VectorState(np.array((3, 2, 1, 1))))
         with self.assertRaises(ValueError):
             self.s2 - self.s3
 
@@ -43,7 +43,7 @@ class TestState(unittest.TestCase):
 
     def test_reorder(self):
         order = np.array([2, 0, 1])
-        self.assertEqual(self.s1.reorder(order), MemorylessState(np.array((3, 1, 2))))
+        self.assertEqual(self.s1.reorder(order), VectorState(np.array((3, 1, 2))))
 
     def test_check_AP(self):
         ordering = (self.complex_1, self.complex_2, self.complex_3)

--- a/Testing/test_vector_model.py
+++ b/Testing/test_vector_model.py
@@ -8,7 +8,7 @@ from Core.Structure import StructureAgent
 from Core.Complex import Complex
 from Parsing.ParseBCSL import Parser, load_TS_from_json
 from TS.Edge import Edge
-from TS.State import MemorylessState
+from TS.State import VectorState
 from TS.TransitionSystem import TransitionSystem
 from TS.VectorModel import VectorModel
 from TS.VectorReaction import VectorReaction
@@ -40,17 +40,17 @@ class TestVectorModel(unittest.TestCase):
         rate_3 = Rate(self.rate_parser.parse(rate_expr).data)
         rate_3.vectorize(ordering, params)
 
-        init = MemorylessState(np.array([2.0, 1.0, 1.0]))
+        init = VectorState(np.array([2.0, 1.0, 1.0]))
 
-        vector_reactions = {VectorReaction(MemorylessState(np.array([0.0, 0.0, 0.0])), MemorylessState(np.array([0.0, 1.0, 0.0])), rate_1),
-                            VectorReaction(MemorylessState(np.array([1.0, 0.0, 0.0])), MemorylessState(np.array([0.0, 0.0, 0.0])), rate_2),
-                            VectorReaction(MemorylessState(np.array([0.0, 0.0, 1.0])), MemorylessState(np.array([1.0, 0.0, 0.0])), None)}
+        vector_reactions = {VectorReaction(VectorState(np.array([0.0, 0.0, 0.0])), VectorState(np.array([0.0, 1.0, 0.0])), rate_1),
+                            VectorReaction(VectorState(np.array([1.0, 0.0, 0.0])), VectorState(np.array([0.0, 0.0, 0.0])), rate_2),
+                            VectorReaction(VectorState(np.array([0.0, 0.0, 1.0])), VectorState(np.array([1.0, 0.0, 0.0])), None)}
 
         self.vm_1 = VectorModel(vector_reactions, init, ordering, None)
 
-        vector_reactions = {VectorReaction(MemorylessState(np.array([0.0, 0.0, 0.0])), MemorylessState(np.array([0.0, 1.0, 0.0])), rate_1),
-                            VectorReaction(MemorylessState(np.array([1.0, 0.0, 0.0])), MemorylessState(np.array([0.0, 0.0, 0.0])), rate_2),
-                            VectorReaction(MemorylessState(np.array([0.0, 0.0, 1.0])), MemorylessState(np.array([1.0, 0.0, 0.0])), rate_3)}
+        vector_reactions = {VectorReaction(VectorState(np.array([0.0, 0.0, 0.0])), VectorState(np.array([0.0, 1.0, 0.0])), rate_1),
+                            VectorReaction(VectorState(np.array([1.0, 0.0, 0.0])), VectorState(np.array([0.0, 0.0, 0.0])), rate_2),
+                            VectorReaction(VectorState(np.array([0.0, 0.0, 1.0])), VectorState(np.array([1.0, 0.0, 0.0])), rate_3)}
 
         self.vm_2 = VectorModel(vector_reactions, init, ordering, None)
 
@@ -115,19 +115,19 @@ class TestVectorModel(unittest.TestCase):
 
         self.test_ts = TransitionSystem(ordering, 2)
 
-        states = [MemorylessState(np.array((0.0, 0.0, 0.0, 0.0, 1.0))),
-                  MemorylessState(np.array((0.0, 0.0, 0.0, 0.0, 0.0))),
-                  MemorylessState(np.array((0.0, 0.0, 1.0, 0.0, 0.0))),
-                  MemorylessState(np.array((0.0, 0.0, 1.0, 0.0, 1.0))),
-                  MemorylessState(np.array((np.inf, np.inf, np.inf, np.inf, np.inf))),
-                  MemorylessState(np.array((0.0, 0.0, 0.0, 1.0, 1.0))),
-                  MemorylessState(np.array((0.0, 0.0, 1.0, 1.0, 1.0))),
-                  MemorylessState(np.array((0.0, 1.0, 0.0, 0.0, 0.0))),
-                  MemorylessState(np.array((0.0, 0.0, 0.0, 1.0, 0.0))),
-                  MemorylessState(np.array((0.0, 0.0, 1.0, 1.0, 0.0))),
-                  MemorylessState(np.array((0.0, 1.0, 1.0, 0.0, 0.0))),
-                  MemorylessState(np.array((0.0, 1.0, 0.0, 1.0, 0.0))),
-                  MemorylessState(np.array((0.0, 1.0, 1.0, 1.0, 0.0)))]
+        states = [VectorState(np.array((0.0, 0.0, 0.0, 0.0, 1.0))),
+                  VectorState(np.array((0.0, 0.0, 0.0, 0.0, 0.0))),
+                  VectorState(np.array((0.0, 0.0, 1.0, 0.0, 0.0))),
+                  VectorState(np.array((0.0, 0.0, 1.0, 0.0, 1.0))),
+                  VectorState(np.array((np.inf, np.inf, np.inf, np.inf, np.inf))),
+                  VectorState(np.array((0.0, 0.0, 0.0, 1.0, 1.0))),
+                  VectorState(np.array((0.0, 0.0, 1.0, 1.0, 1.0))),
+                  VectorState(np.array((0.0, 1.0, 0.0, 0.0, 0.0))),
+                  VectorState(np.array((0.0, 0.0, 0.0, 1.0, 0.0))),
+                  VectorState(np.array((0.0, 0.0, 1.0, 1.0, 0.0))),
+                  VectorState(np.array((0.0, 1.0, 1.0, 0.0, 0.0))),
+                  VectorState(np.array((0.0, 1.0, 0.0, 1.0, 0.0))),
+                  VectorState(np.array((0.0, 1.0, 1.0, 1.0, 0.0)))]
 
         # in edges we have probabilities, not rates, so we must normalise
         go = gamma + omega  # 5

--- a/Testing/test_vector_model.py
+++ b/Testing/test_vector_model.py
@@ -156,7 +156,8 @@ class TestVectorModel(unittest.TestCase):
                               Edge(states[12], states[4], 1)
                               }
 
-        self.test_ts.encode(states[0])
+        self.test_ts.init = states[0]
+        self.test_ts.encode()
 
         # bigger TS
 
@@ -291,28 +292,28 @@ class TestVectorModel(unittest.TestCase):
         loaded_ts = load_TS_from_json("Testing/ts_pMC.json")
         self.assertEqual(generated_ts, loaded_ts)
 
-    def test_generate_transition_system_interrupt(self):
-        model = self.model_parser.parse(self.model_even_bigger_TS).data
-        vector_model = model.to_vector_model()
-
-        # partially generate TS with max ~1000 states
-        generated_ts = vector_model.generate_transition_system(max_size=1000)
-        # was interrupted
-        generated_ts.save_to_json("Testing/TS_in_progress.json")
-        loaded_unfinished_ts = load_TS_from_json("Testing/TS_in_progress.json")
-
-        # continue in generating with max ~5000 states
-        generated_ts = vector_model.generate_transition_system(loaded_unfinished_ts, max_size=5000)
-        generated_ts.save_to_json("Testing/TS_in_progress.json")
-        loaded_unfinished_ts = load_TS_from_json("Testing/TS_in_progress.json")
-
-        # finish the TS
-        generated_ts = vector_model.generate_transition_system(loaded_unfinished_ts)
-
-        generated_ts.save_to_json("Testing/TS_finished.json")
-        loaded_ts = load_TS_from_json("Testing/interrupt_even_bigger_ts.json")
-
-        self.assertEqual(generated_ts, loaded_ts)
+    # def test_generate_transition_system_interrupt(self):
+    #     model = self.model_parser.parse(self.model_even_bigger_TS).data
+    #     vector_model = model.to_vector_model()
+    #
+    #     # partially generate TS with max ~1000 states
+    #     generated_ts = vector_model.generate_transition_system(max_size=1000)
+    #     # was interrupted
+    #     generated_ts.save_to_json("Testing/TS_in_progress.json")
+    #     loaded_unfinished_ts = load_TS_from_json("Testing/TS_in_progress.json")
+    #
+    #     # continue in generating with max ~5000 states
+    #     generated_ts = vector_model.generate_transition_system(loaded_unfinished_ts, max_size=5000)
+    #     generated_ts.save_to_json("Testing/TS_in_progress.json")
+    #     loaded_unfinished_ts = load_TS_from_json("Testing/TS_in_progress.json")
+    #
+    #     # finish the TS
+    #     generated_ts = vector_model.generate_transition_system(loaded_unfinished_ts)
+    #
+    #     generated_ts.save_to_json("Testing/TS_finished.json")
+    #     loaded_ts = load_TS_from_json("Testing/interrupt_even_bigger_ts.json")
+    #
+    #     self.assertEqual(generated_ts, loaded_ts)
 
     def test_handle_sinks(self):
         model = self.model_parser.parse(self.model_with_sinks).data


### PR DESCRIPTION
Allowed regulation also using indirect approach (reactions are generated and converted to vectors). Every reaction inherits label from its parent rule. Then the regulation process works the same way as in the direct case. This enables possibly faster computation of transition system.

Also added new feature - **replication** type of rules - in a rule of form: `A -> 2 A` the two produced `A`s are identical to the `A` on the right-hand side. 

Just for info - @xsafran1 you might be interested in these updates.