### PR TITLE
Grammar improvements

### DIFF
--- a/Core/Rule.py
+++ b/Core/Rule.py
@@ -241,6 +241,36 @@ class Rule:
             output_complexes.append(Complex(match[f:t + 1], self.compartments[f]))
         return Multiset(collections.Counter(output_complexes))
 
+    def create_reversible(self):
+        """
+        Create a reversible version of the rule with _bw label.
+
+        Also add implicit _fw label to current Rule.
+
+        TODO: allow two rates
+
+        @return: reversed Rule
+        """
+        agents = self.agents[self.mid:] + self.agents[:self.mid]
+        mid = len(self.agents) - self.mid
+        compartments = self.compartments[self.mid:] + self.compartments[:self.mid]
+        complexes = sorted([((f - self.mid) % len(self.agents),
+                             (t - self.mid) % len(self.agents)) for (f, t) in self.complexes])
+        pairs = []
+        for (l, r) in self.pairs:
+            if l is None or r is None:
+                pairs.append((r, l))
+            else:
+                pairs.append((l, r))
+
+        rate = self.rate
+        label = None
+        if self.label:
+            label = self.label + "_bw"
+            self.label += "_fw"
+
+        return Rule(agents, mid, compartments, complexes, pairs, rate, label)
+
 
 def find_all_matches(lhs_agents, state):
     """

--- a/Parsing/ParseBCSL.py
+++ b/Parsing/ParseBCSL.py
@@ -84,7 +84,7 @@ class SideHelper:
 
 
 GRAMMAR = r"""
-    model: rules inits (definitions)? (complexes)? (regulation)?
+    model: rules (inits)? (definitions)? (complexes)? (regulation)?
 
     rules: RULES_START (rule|COMMENT)+
     inits: INITS_START (init|COMMENT)+
@@ -466,6 +466,7 @@ class TreeToObjects(Transformer):
     def model(self, matches):
         definitions = dict()
         regulation = None
+        inits = collections.Counter()
         for match in matches:
             if type(match) == dict:
                 key, value = list(match.items())[0]

--- a/Testing/test_model.py
+++ b/Testing/test_model.py
@@ -489,7 +489,7 @@ class TestModel(unittest.TestCase):
                          {"unexpected": ";", "expected": {'?', 'name'}, "line": 3, "column": 37})
 
         self.assertEqual(self.model_parser.parse(self.model_wrong_2).data,
-                         {"expected": {'decimal', '#! inits', ']', '#! definitions', '=>', '@', 'int',
+                         {"expected": {'decimal', '#! inits', ']', '#! definitions', '=>, <=>', '@', 'int',
                                        '+', 'name', ';', '}', ',', '#! complexes', '#! regulation'},
                           "line": 3, "column": 26, "unexpected": "="})
 

--- a/Testing/test_rule.py
+++ b/Testing/test_rule.py
@@ -193,32 +193,32 @@ class TestRule(unittest.TestCase):
                          {self.reaction_c1_1})
 
         rule_exp = "K(T{a}).K().K()::cyt => K(T{i}).K().K()::cyt @ k1*[K(T{a}).K().K()::cyt]"
-        rule = self.parser.parse(rule_exp).data
+        rule = self.parser.parse(rule_exp).data[1]
         result = rule.create_reactions(atomic_signature, structure_signature)
 
         reactions = set()
         with open("Testing/reactions.txt") as file:
             for complex in file.readlines():
-                rule = self.parser.parse(complex).data
+                rule = self.parser.parse(complex).data[1]
                 reactions.add(rule.to_reaction())
 
         self.assertEqual(result, reactions)
 
     def test_parser(self):
         rule_expr = "K(S{u}).B()::cyt => K(S{p})::cyt + B()::cyt + D(B{_})::cell @ 3*[K()::cyt]/2*v_1"
-        self.assertEqual(self.parser.parse(rule_expr).data, self.r2)
+        self.assertEqual(self.parser.parse(rule_expr).data[1], self.r2)
 
         rule_expr = "K(B{-}).B()::cyt + D(B{_})::cell => K(B{+})::cyt + B()::cyt @ 3*[K(T{3+})::cyt]/2*v_1"
-        self.assertEqual(self.parser.parse(rule_expr).data, self.r3)
+        self.assertEqual(self.parser.parse(rule_expr).data[1], self.r3)
 
         rule_expr = "X()::rep => @ k1*[X()::rep]"
-        self.assertEqual(self.parser.parse(rule_expr).data, self.r4)
+        self.assertEqual(self.parser.parse(rule_expr).data[1], self.r4)
 
         rule_expr = "=> Y()::rep @ 1/(1+([X()::rep])**4)"
-        self.assertEqual(self.parser.parse(rule_expr).data, self.r5)
+        self.assertEqual(self.parser.parse(rule_expr).data[1], self.r5)
 
         rule_expr = "K(S{u}).B()::cyt => K(S{p})::cyt + B()::cyt"
-        self.assertEqual(self.parser.parse(rule_expr).data, self.rule_no_rate)
+        self.assertEqual(self.parser.parse(rule_expr).data[1], self.rule_no_rate)
 
     def test_compatible(self):
         self.assertTrue(self.r1.compatible(self.r2))
@@ -226,48 +226,48 @@ class TestRule(unittest.TestCase):
 
         rule_expr_1 = "K(S{u}).B()::cyt => K(S{p})::cyt + B()::cyt + D(B{_})::cell @ 3*[K()::cyt]/2*v_1"
         rule_expr_2 = "K().B()::cyt => K()::cyt + B()::cyt + D(B{_})::cell @ 3*[K()::cyt]/2*v_1"
-        rule1 = self.parser.parse(rule_expr_1).data
-        rule2 = self.parser.parse(rule_expr_2).data
+        rule1 = self.parser.parse(rule_expr_1).data[1]
+        rule2 = self.parser.parse(rule_expr_2).data[1]
 
         self.assertFalse(rule1.compatible(rule2))
         self.assertTrue(rule2.compatible(rule1))
 
     def test_reduce_context(self):
         rule_expr_1 = "K(S{u}).B{i}::cyt => K(S{p})::cyt + B{a}::cyt + D(B{_})::cell @ 3*[K(S{u}).B{i}::cyt]/2*v_1"
-        rule1 = self.parser.parse(rule_expr_1).data
+        rule1 = self.parser.parse(rule_expr_1).data[1]
 
         rule_expr_2 = "K().B{_}::cyt => K()::cyt + B{_}::cyt + D()::cell @ 3*[K().B{_}::cyt]/2*v_1"
-        rule2 = self.parser.parse(rule_expr_2).data
+        rule2 = self.parser.parse(rule_expr_2).data[1]
 
         self.assertEqual(rule1.reduce_context(), rule2)
 
         # next case
 
         rule_expr_1 = "K(S{u})::cyt => K(S{p})::cyt + D(B{_})::cell @ 3*[K(S{u})::cyt]/2*v_1"
-        rule1 = self.parser.parse(rule_expr_1).data
+        rule1 = self.parser.parse(rule_expr_1).data[1]
 
         rule_expr_2 = "K()::cyt => K()::cyt + D()::cell @ 3*[K()::cyt]/2*v_1"
-        rule2 = self.parser.parse(rule_expr_2).data
+        rule2 = self.parser.parse(rule_expr_2).data[1]
 
         self.assertEqual(rule1.reduce_context(), rule2)
 
         # next case - covering replication
 
         rule_expr_1 = "K(S{u})::cyt => 2 K(S{u})::cyt @ 3*[K(S{u})::cyt]/2*v_1"
-        rule1 = self.parser.parse(rule_expr_1).data
+        rule1 = self.parser.parse(rule_expr_1).data[1]
 
         rule_expr_2 = "K()::cyt => 2 K()::cyt @ 3*[K()::cyt]/2*v_1"
-        rule2 = self.parser.parse(rule_expr_2).data
+        rule2 = self.parser.parse(rule_expr_2).data[1]
 
         self.assertEqual(rule1.reduce_context(), rule2)
 
         # next case - covering replication
 
         rule_expr_1 = "K(S{u})::cyt => 3 K(S{u})::cyt @ 3*[K(S{u})::cyt]/2*v_1"
-        rule1 = self.parser.parse(rule_expr_1).data
+        rule1 = self.parser.parse(rule_expr_1).data[1]
 
         rule_expr_2 = "K()::cyt => 3 K()::cyt @ 3*[K()::cyt]/2*v_1"
-        rule2 = self.parser.parse(rule_expr_2).data
+        rule2 = self.parser.parse(rule_expr_2).data[1]
 
         self.assertEqual(rule1.reduce_context(), rule2)
 
@@ -277,6 +277,6 @@ class TestRule(unittest.TestCase):
         complex = complex_parser.parse(agent).data.children[0]
 
         rule_expr = "K().A{i}::cyt => K().A{a}::cyt"
-        rule = self.parser.parse(rule_expr).data
+        rule = self.parser.parse(rule_expr).data[1]
 
         self.assertTrue(rule.exists_compatible_agent(complex))

--- a/Visualisations/BCSLeditor/templates/BCSLeditor.mako
+++ b/Visualisations/BCSLeditor/templates/BCSLeditor.mako
@@ -115,7 +115,7 @@ data = "\n".join(list(hda.datatype.dataprovider( hda, 'line', comment_char=none,
                 var cont = ace.edit('editor').getValue();
                 var dInputs = {
                     dbkey: '?',
-                    file_type: 'auto',
+                    file_type: 'bcs',
                     'files_0|type': 'upload_dataset',
                     'files_0|space_to_tab': null,
                     'files_0|to_posix_lines': 'Yes'

--- a/config/datatypes/datatypes.py
+++ b/config/datatypes/datatypes.py
@@ -14,7 +14,7 @@ class BCS(Text):
         """
         content = open(filename, 'r').read()
         keywords = ["#! rules", "#! inits", "#! definitions"]
-        return all(keyword in content for keyword in keywords)
+        return any(keyword in content for keyword in keywords)
 
 class BCS_TS(Text):
     """Class describing a .bcs.ts file"""


### PR DESCRIPTION
This PR covers several smaller issues found by users.

- allowed usage of complex aliases in complexes and nesting complex aliases in their definition (close #33)
- allowed usage of bidirectional rules (#30) and assigned them implicit labels (close #27)
- allowed empty initial state (close #29)
- fixed BCSLeditor output file format - `.bcs` instead `.txt` (close #31)