### PR TITLE
Fix transforming rules

### DIFF
--- a/eBCSgen/Core/Atomic.py
+++ b/eBCSgen/Core/Atomic.py
@@ -49,7 +49,7 @@ class AtomicAgent:
 
         If other is also an atomic agents, this methods gives them both the same states
         according to the given atomic_signature.
-        Otherwise, context is filled independently and other part is None.
+        Otherwise, context is filled independently and other part is None, unless it's a StructureAgent.
         Finally, if both agents have defined states, they are returned untouched.
 
         Note: it is assumed this method is used only for well formed rules, which means
@@ -76,12 +76,14 @@ class AtomicAgent:
                     result.add((None, AtomicAgent(str(self.name), state)))
             else:
                 result = {(None, self)}
-        else:
+        elif other == 1:
             if self.state == "_":
                 for state in atomic_signature[self.name]:
                     result.add((AtomicAgent(str(self.name), state), None))
             else:
                 result = {(self, None)}
+        else:
+            return {(self, other)}
         return result
 
     def reduce_context(self):

--- a/eBCSgen/Core/Structure.py
+++ b/eBCSgen/Core/Structure.py
@@ -113,11 +113,18 @@ class StructureAgent:
                     new_agent.composition.add(left)
                 if other == -1:
                     agents.add((None, new_agent))
-                else:
+                elif other == 1:
                     agents.add((new_agent, None))
+                else:
+                    return {(self, other)}
             return agents
         else:
-            return {(None, self)} if other == -1 else {(self, None)}
+            if other == -1:
+                return {(None, self)}
+            elif other == 1:
+                return {(self, None)}
+            else:
+                return {(self, other)}
 
     def reduce_context(self):
         """


### PR DESCRIPTION
It was assumed that in `add_context` methods if `other` argument is not of the same type as self, it is always empty. But actually, it can still be another type of agent.

Close #60.