### PR TITLE
Added tests for replacing abstract syntax

### DIFF
--- a/Testing/parsing/test_insert_atomic_to_complex.py
+++ b/Testing/parsing/test_insert_atomic_to_complex.py
@@ -5,12 +5,13 @@ from eBCSgen.Errors.ComplexParsingError import ComplexParsingError
 from eBCSgen.Parsing.ParseBCSL import Parser, TransformAbstractSyntax
 
 
-def test_insert_atomic_to_complex_unspecified_first():
+@pytest.mark.parametrize('string_atomic, string_value, string_expected', [
+    ["A{i}", "B(S{p}).A{_}.A{d}", "B(S{p}).A{i}.A{d}"],
+    ["A{i}", "B(S{p}).A{d}.A{_}", "B(S{p}).A{d}.A{i}"]
+])
+def test_insert_atomic_to_complex_correct_input(string_atomic, string_value, string_expected):
     parser_atomic = Parser("atomic")
     parser_value = Parser("value")
-
-    string_atomic = "A{i}"
-    string_value = "B(S{p}).A{_}.A{d}"
 
     result_atomic = parser_atomic.syntax_check(string_atomic).data.children[0]
     result_value = parser_value.syntax_check(string_value).data.children[0]
@@ -18,18 +19,18 @@ def test_insert_atomic_to_complex_unspecified_first():
     transformer = TransformAbstractSyntax(set())
     transformed_value = transformer.insert_atomic_to_complex(result_atomic, result_value)
 
-    string_expected = "B(S{p}).A{i}.A{d}"
     result_expected = parser_value.syntax_check(string_expected).data.children[0]
 
     assert transformed_value == result_expected
 
 
-def test_insert_atomic_to_complex_specified():
+@pytest.mark.parametrize('string_atomic, string_value', [
+    ["A{i}", "B(S{p}).A{a}.A{d}"],
+    ["A{_}", "B(S{p}).A{d}.A{a}"]
+])
+def test_insert_atomic_to_complex_incorrect_input(string_atomic, string_value):
     parser_atomic = Parser("atomic")
     parser_value = Parser("value")
-
-    string_atomic = "A{i}"
-    string_value = "B(S{p}).A{a}.A{d}"
 
     result_atomic = parser_atomic.syntax_check(string_atomic).data.children[0]
     result_value = parser_value.syntax_check(string_value).data.children[0]
@@ -38,22 +39,3 @@ def test_insert_atomic_to_complex_specified():
 
     with pytest.raises(ComplexParsingError):
         _ = transformer.insert_atomic_to_complex(result_atomic, result_value)
-
-
-def test_insert_atomic_to_complex_unspecified_second():
-    parser_atomic = Parser("atomic")
-    parser_value = Parser("value")
-
-    string_atomic = "A{i}"
-    string_value = "B(S{p}).A{d}.A{_}"
-
-    result_atomic = parser_atomic.syntax_check(string_atomic).data.children[0]
-    result_value = parser_value.syntax_check(string_value).data.children[0]
-
-    transformer = TransformAbstractSyntax(set())
-    transformed_value = transformer.insert_atomic_to_complex(result_atomic, result_value)
-
-    string_expected = "B(S{p}).A{d}.A{i}"
-    result_expected = parser_value.syntax_check(string_expected).data.children[0]
-
-    assert transformed_value == result_expected

--- a/Testing/parsing/test_insert_atomic_to_complex.py
+++ b/Testing/parsing/test_insert_atomic_to_complex.py
@@ -26,7 +26,8 @@ def test_insert_atomic_to_complex_correct_input(string_atomic, string_value, str
 
 @pytest.mark.parametrize('string_atomic, string_value', [
     ["A{i}", "B(S{p}).A{a}.A{d}"],
-    ["A{_}", "B(S{p}).A{d}.A{a}"]
+    ["A{_}", "B(S{p}).A{d}.A{a}"],
+    ["A{i}", "B(S{p}).D{d}"]
 ])
 def test_insert_atomic_to_complex_incorrect_input(string_atomic, string_value):
     parser_atomic = Parser("atomic")

--- a/Testing/parsing/test_insert_atomic_to_struct.py
+++ b/Testing/parsing/test_insert_atomic_to_struct.py
@@ -1,0 +1,41 @@
+import pytest
+
+
+from eBCSgen.Errors.ComplexParsingError import ComplexParsingError
+from eBCSgen.Parsing.ParseBCSL import Parser, TransformAbstractSyntax
+
+
+@pytest.mark.parametrize('string_atomic, string_structure, string_expected', [
+    ["A{i}", "B(S{p})", "B(S{p},A{i})"],
+    ["A{i}", "B()", "B(A{i})"]
+])
+def test_insert_atomic_to_struct_correct_input(string_atomic, string_structure, string_expected):
+    parser_atomic = Parser("atomic")
+    parser_structure = Parser("structure")
+
+    result_atomic = parser_atomic.syntax_check(string_atomic).data.children[0]
+    result_structure = parser_structure.syntax_check(string_structure).data.children[0]
+
+    transformer = TransformAbstractSyntax(set())
+    transformed_value = transformer.insert_atomic_to_struct(result_atomic, result_structure)
+
+    result_expected = parser_structure.syntax_check(string_expected).data.children[0]
+
+    assert transformed_value == result_expected
+
+
+@pytest.mark.parametrize('string_atomic, string_structure', [
+    ["A{i}", "B(A{a})"],
+    ["A{i}", "B(A{i})"]
+])
+def test_insert_atomic_to_struct_incorrect_input(string_atomic, string_structure):
+    parser_atomic = Parser("atomic")
+    parser_structure = Parser("structure")
+
+    result_atomic = parser_atomic.syntax_check(string_atomic).data.children[0]
+    result_structure = parser_structure.syntax_check(string_structure).data.children[0]
+
+    transformer = TransformAbstractSyntax(set())
+
+    with pytest.raises(ComplexParsingError):
+        _ = transformer.insert_atomic_to_struct(result_atomic, result_structure)

--- a/Testing/parsing/test_insert_struct_to_complex.py
+++ b/Testing/parsing/test_insert_struct_to_complex.py
@@ -1,0 +1,44 @@
+import pytest
+
+
+from eBCSgen.Errors.ComplexParsingError import ComplexParsingError
+from eBCSgen.Parsing.ParseBCSL import Parser, TransformAbstractSyntax
+
+
+@pytest.mark.parametrize('string_structure, string_value, string_expected', [
+    ["B(S{i})", "B().A{_}.B(S{a}).A{d}", "B(S{i}).A{_}.B(S{a}).A{d}"],
+    ["B()", "B().A{_}.B(S{a}).A{d}", "B().A{_}.B(S{a}).A{d}"],
+    ["B(S{i})", "B(S{a}).A{_}.B().A{d}", "B(S{a}).A{_}.B(S{i}).A{d}"],
+    ["B(S{i})", "B(T{a}).A{_}.B().A{d}", "B(T{a},S{i}).A{_}.B().A{d}"]
+])
+def test_insert_struct_to_complex_correct_input(string_structure, string_value, string_expected):
+    parser_structure = Parser("structure")
+    parser_value = Parser("value")
+
+    result_structure = parser_structure.syntax_check(string_structure).data.children[0]
+    result_value = parser_value.syntax_check(string_value).data.children[0]
+
+    transformer = TransformAbstractSyntax(set())
+    transformed_value = transformer.insert_struct_to_complex(result_structure, result_value)
+
+    result_expected = parser_value.syntax_check(string_expected).data.children[0]
+
+    assert transformed_value == result_expected
+
+
+@pytest.mark.parametrize('string_structure, string_value', [
+    ["B()", "F(S{p}).A{a}.A{d}"],
+    ["B(S{i})", "B(S{p}).A{d}.A{a}"],
+    ["B(S{i})", "B(S{p}).A{d}.B(S{i}).A{a}"]
+])
+def test_insert_struct_to_complex_incorrect_input(string_structure, string_value):
+    parser_structure = Parser("structure")
+    parser_value = Parser("value")
+
+    result_structure = parser_structure.syntax_check(string_structure).data.children[0]
+    result_value = parser_value.syntax_check(string_value).data.children[0]
+
+    transformer = TransformAbstractSyntax(set())
+
+    with pytest.raises(ComplexParsingError):
+        _ = transformer.insert_struct_to_complex(result_structure, result_value)

--- a/Testing/parsing/test_parsing.py
+++ b/Testing/parsing/test_parsing.py
@@ -1,0 +1,59 @@
+import pytest
+
+
+from eBCSgen.Errors.ComplexParsingError import ComplexParsingError
+from eBCSgen.Parsing.ParseBCSL import Parser, TransformAbstractSyntax
+
+
+def test_insert_atomic_to_complex_unspecified_first():
+    parser_atomic = Parser("atomic")
+    parser_value = Parser("value")
+
+    string_atomic = "A{i}"
+    string_value = "B(S{p}).A{_}.A{d}"
+
+    result_atomic = parser_atomic.syntax_check(string_atomic).data.children[0]
+    result_value = parser_value.syntax_check(string_value).data.children[0]
+
+    transformer = TransformAbstractSyntax(set())
+    transformed_value = transformer.insert_atomic_to_complex(result_atomic, result_value)
+
+    string_expected = "B(S{p}).A{i}.A{d}"
+    result_expected = parser_value.syntax_check(string_expected).data.children[0]
+
+    assert transformed_value == result_expected
+
+
+def test_insert_atomic_to_complex_specified():
+    parser_atomic = Parser("atomic")
+    parser_value = Parser("value")
+
+    string_atomic = "A{i}"
+    string_value = "B(S{p}).A{a}.A{d}"
+
+    result_atomic = parser_atomic.syntax_check(string_atomic).data.children[0]
+    result_value = parser_value.syntax_check(string_value).data.children[0]
+
+    transformer = TransformAbstractSyntax(set())
+
+    with pytest.raises(ComplexParsingError):
+        _ = transformer.insert_atomic_to_complex(result_atomic, result_value)
+
+
+def test_insert_atomic_to_complex_unspecified_second():
+    parser_atomic = Parser("atomic")
+    parser_value = Parser("value")
+
+    string_atomic = "A{i}"
+    string_value = "B(S{p}).A{d}.A{_}"
+
+    result_atomic = parser_atomic.syntax_check(string_atomic).data.children[0]
+    result_value = parser_value.syntax_check(string_value).data.children[0]
+
+    transformer = TransformAbstractSyntax(set())
+    transformed_value = transformer.insert_atomic_to_complex(result_atomic, result_value)
+
+    string_expected = "B(S{p}).A{d}.A{i}"
+    result_expected = parser_value.syntax_check(string_expected).data.children[0]
+
+    assert transformed_value == result_expected


### PR DESCRIPTION
Write tests for all insert functions of `TransformAbstractSyntax` transformer.

Creates test cases for #72 