### PR TITLE
enable direct usage of complexes

### DIFF
--- a/Testing/models/model_cmplx_in_abstr_seq1.txt
+++ b/Testing/models/model_cmplx_in_abstr_seq1.txt
@@ -1,0 +1,5 @@
+#! rules
+S{i}:A():A2::cell  => A()::cell
+
+#! complexes
+A2 = A().A()

--- a/Testing/models/model_cmplx_in_abstr_seq2.txt
+++ b/Testing/models/model_cmplx_in_abstr_seq2.txt
@@ -1,0 +1,2 @@
+#! rules
+S{i}:A():A().A()::cell => A()::cell

--- a/Testing/parsing/test_cmplx_in_abstr_seq.py
+++ b/Testing/parsing/test_cmplx_in_abstr_seq.py
@@ -1,0 +1,17 @@
+import pytest
+
+from Testing.models.get_model_str import get_model_str
+import Testing.objects_testing as objects
+
+
+def test_complexes_in_abstract_sequence():
+    # is allowed
+    model = get_model_str("model_cmplx_in_abstr_seq1")
+    ret1 = objects.model_parser.parse(model)
+    assert ret1.success
+
+    # should be allowed
+    model = get_model_str("model_cmplx_in_abstr_seq2")
+    ret2 = objects.model_parser.parse(model)
+    assert ret2.success
+    assert ret1.data == ret2.data

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -412,12 +412,12 @@ class TransformAbstractSyntax(Transformer):
                 # search same name structs - if they contain atomics with matching names, they are considered incompatible
                 for j in range(len(struct.children[1].children)):
                     for k in range(
-                        len(complex.children[i].children[0].children[1].children)
+                        len(search.children[i].children[0].children[1].children)
                     ):
                         if self.get_name(
                             struct.children[1].children[j]
                         ) == self.get_name(
-                            complex.children[i].children[0].children[1].children[k]
+                            search.children[i].children[0].children[1].children[k]
                         ):
                             struct_found = False
                             break

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -348,6 +348,10 @@ class TransformAbstractSyntax(Transformer):
             if self.get_name(struct) == self.get_name(complex.children[i].children[0]):
                 complex.children[i] = Tree('agent', [struct])
                 break
+            elif isinstance(complex.children[0].children[0].children[0].children[0], Tree):
+                complex.children[i].children[0] = Tree('agent', [struct])
+                break
+
         return complex
 
     def insert_atomic_to_complex(self, atomic, complex):

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -137,9 +137,9 @@ GRAMMAR = r"""
 
 EXTENDED_GRAMMAR = """
     abstract_sequence: atomic_complex | atomic_structure_complex | structure_complex
-    atomic_complex: atomic ":" (cmplx_name|VAR)
-    atomic_structure_complex: atomic ":" structure ":" (cmplx_name|VAR)
-    structure_complex: structure ":" (cmplx_name|VAR)
+    atomic_complex: atomic ":" (VAR | value)
+    atomic_structure_complex: atomic ":" structure ":" (VAR | value)
+    structure_complex: structure ":" (VAR | value)
 
     variable: VAR "=" "{" cmplx_name ("," cmplx_name)+ "}"
     VAR: "?"


### PR DESCRIPTION
Close #89 - use complexes directly in `abstract_sequence`. 

Altering `cmplx_name` to `value` in the `EXTENDED_GRAMMAR` enabled us to not only use aliases but also complexes in abstract sequences.