### PR TITLE
Improve grammar syntax

### DIFF
--- a/Testing/objects_testing.py
+++ b/Testing/objects_testing.py
@@ -178,7 +178,7 @@ counter_c6 = Complex(collections.Counter({s45: 1}), "cell")
 
 cx1 = Complex([a20], "cyt")
 cx2 = Complex([s46], "cyt")
-cx3 = Complex([s47], "cyt") # K(S{u},T{i})::cyt
+cx3 = Complex([s47], "cyt")  # K(S{u},T{i})::cyt
 cx4 = Complex([s46, a20], "cyt")
 cx5 = Complex([s47, a20], "cyt")
 
@@ -261,7 +261,7 @@ complexes_5 = [(0, 1), (2, 2), (3, 3), (4, 4)]
 pairs_5 = [(0, 2), (1, 3), (None, 4)]
 rate_5 = Rate("3.0*[K()::cyt]/2.0*v_1")
 
-r5 = Rule(sequence_5, mid_5, compartments_5, complexes_5, pairs_2, rate_5)
+r5 = Rule(sequence_5, mid_5, compartments_5, complexes_5, pairs_5, rate_5)
 
 sequence_6 = (s39, s35, s38, s40, s37)
 mid_6 = 3

--- a/Testing/parsing/test_complex.py
+++ b/Testing/parsing/test_complex.py
@@ -2,57 +2,59 @@ import Testing.objects_testing as objects
 
 
 def test_parser():
-    ret = objects.complex_parser.parse("B(T{s})::cell")
+    ret = objects.rate_complex_parser.parse("B(T{s})::cell")
     assert ret.success
     assert ret.data.children[0] == objects.c1
 
-    ret = objects.complex_parser.parse("B(T{s}).D().K(T{s},S{s},S{_})::cell")
+    ret = objects.rate_complex_parser.parse("B(T{s}).D().K(T{s},S{s},S{_})::cell")
     assert ret.success
     assert ret.data.children[0] == objects.c2
 
-    ret = objects.complex_parser.parse("B(T{s}).K(T{s}, S{s}, S{_}).D(S{_},T{p})::cyt")
+    ret = objects.rate_complex_parser.parse(
+        "B(T{s}).K(T{s}, S{s}, S{_}).D(S{_},T{p})::cyt"
+    )
     assert ret.success
     assert ret.data.children[0] == objects.c3
 
-    ret = objects.complex_parser.parse("B(T{s}).T{s}::cyt")
+    ret = objects.rate_complex_parser.parse("B(T{s}).T{s}::cyt")
     assert ret.success
     assert ret.data.children[0] == objects.c4
 
-    ret = objects.complex_parser.parse("D().D().D().B(T{_}).B(T{_}).B(T{_})::cell")
+    ret = objects.rate_complex_parser.parse("D().D().D().B(T{_}).B(T{_}).B(T{_})::cell")
     assert ret.success
     assert ret.data.children[0] == objects.c5
 
-    ret = objects.complex_parser.parse("K().K().T{p}::cyt")
+    ret = objects.rate_complex_parser.parse("K().K().T{p}::cyt")
     assert ret.success
     assert ret.data.children[0] == objects.c6
 
-    ret = objects.complex_parser.parse("T{u}.T{_}::cell")
+    ret = objects.rate_complex_parser.parse("T{u}.T{_}::cell")
     assert ret.success
     assert ret.data.children[0] == objects.c7
 
-    ret = objects.complex_parser.parse("(T{s})::cell")
+    ret = objects.rate_complex_parser.parse("(T{s})::cell")
     assert not ret.success
 
-    ret = objects.complex_parser.parse("()::cell")
+    ret = objects.rate_complex_parser.parse("()::cell")
     assert not ret.success
 
-    ret = objects.complex_parser.parse("x::cell")
+    ret = objects.rate_complex_parser.parse("x::cell")
     assert not ret.success
 
-    ret = objects.complex_parser.parse("BT{s})::cell")
+    ret = objects.rate_complex_parser.parse("BT{s})::cell")
     assert not ret.success
 
-    ret = objects.complex_parser.parse("B(T{s}::cell")
+    ret = objects.rate_complex_parser.parse("B(T{s}::cell")
     assert not ret.success
 
-    ret = objects.complex_parser.parse("B(T{s}::cell)")
+    ret = objects.rate_complex_parser.parse("B(T{s}::cell)")
     assert not ret.success
 
-    ret = objects.complex_parser.parse("B(T{})::cell")
+    ret = objects.rate_complex_parser.parse("B(T{})::cell")
     assert not ret.success
 
-    ret = objects.complex_parser.parse("B(T{s}))::cell")
+    ret = objects.rate_complex_parser.parse("B(T{s}))::cell")
     assert not ret.success
 
-    ret = objects.complex_parser.parse("B(T{s})::")
+    ret = objects.rate_complex_parser.parse("B(T{s})::")
     assert not ret.success

--- a/Testing/test_complex.py
+++ b/Testing/test_complex.py
@@ -55,6 +55,7 @@ class TestComplex(unittest.TestCase):
         results = set()
         with open("Testing/complexes_1.txt") as file:
             for complex in file.readlines():
+                complex = complex.strip()
                 results.add(objects.rate_complex_parser.parse(complex).data.children[0])
 
         complex = objects.rate_complex_parser.parse(
@@ -71,6 +72,7 @@ class TestComplex(unittest.TestCase):
         results = set()
         with open("Testing/complexes_2.txt") as file:
             for complex in file.readlines():
+                complex = complex.strip()
                 results.add(objects.rate_complex_parser.parse(complex).data.children[0])
 
         complex = objects.rate_complex_parser.parse(

--- a/Testing/test_rule.py
+++ b/Testing/test_rule.py
@@ -37,6 +37,7 @@ class TestRule(unittest.TestCase):
         reactions = set()
         with open("Testing/reactions.txt") as file:
             for complex in file.readlines():
+                complex = complex.strip()
                 rule = objects.rule_parser.parse(complex).data[1]
                 reactions.add(rule.to_reaction())
 

--- a/Testing/test_side.py
+++ b/Testing/test_side.py
@@ -36,10 +36,12 @@ class TestSide(unittest.TestCase):
         results = set()
         with open("Testing/complexes_1.txt") as file:
             for complex in file.readlines():
+                complex = complex.strip()
                 results.add(objects.rate_complex_parser.parse(complex).data.children[0])
 
         with open("Testing/complexes_2.txt") as file:
             for complex in file.readlines():
+                complex = complex.strip()
                 results.add(objects.rate_complex_parser.parse(complex).data.children[0])
 
         side = "KaiC().KaiC().KaiC().KaiC().KaiC().KaiC()::cyt + 2 KaiB().KaiB().KaiB()::cyt"

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -1,6 +1,7 @@
 import collections
 import json
 import numpy as np
+import os
 from numpy import inf
 from copy import deepcopy
 from lark import Lark, Transformer, Tree
@@ -87,9 +88,6 @@ class SideHelper:
 
 
 GRAMMAR = r"""
-    model: (sections)* rules (sections | rules)*
-    sections: inits | definitions | complexes | regulation
-
     rules: RULES_START _NL+ ((rule|COMMENT) _NL+)* rule _NL*
     inits: INITS_START _NL+ ((init|COMMENT) _NL+)* init _NL*
     definitions: DEFNS_START _NL+ ((definition|COMMENT) _NL+)* definition _NL*
@@ -134,7 +132,6 @@ GRAMMAR = r"""
     %import common.INT
     %import common.DECIMAL
     %import common.WS_INLINE
-    %import common.EOF
     %ignore WS_INLINE
     %ignore COMMENT
 """
@@ -616,7 +613,9 @@ class TreeToObjects(Transformer):
 
 class Parser:
     def __init__(self, start):
-        grammar = "start: " + start + GRAMMAR + COMPLEX_GRAMMAR + EXTENDED_GRAMMAR + REGULATIONS_GRAMMAR
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "model_permutation.txt"), "r") as file:
+            model_grammar = file.read()
+        grammar = "start: " + start + model_grammar + GRAMMAR + COMPLEX_GRAMMAR + EXTENDED_GRAMMAR + REGULATIONS_GRAMMAR
         self.parser = Lark(grammar, parser='lalr',
                            propagate_positions=False,
                            maybe_placeholders=False

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -665,7 +665,7 @@ class TreeToObjects(Transformer):
                 if key == "definitions":
                     definitions.update(value)
                 if key == "regulation":
-                    regulation.update(value)
+                    regulation = value
         params = self.params - set(definitions)
         return Model(rules, inits, definitions, params, regulation)
 

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -24,7 +24,8 @@ from eBCSgen.TS.TransitionSystem import TransitionSystem
 from eBCSgen.TS.Edge import edge_from_dict
 from eBCSgen.Core.Side import Side
 from eBCSgen.Core.Model import Model
-from eBCSgen.Errors import ComplexParsingError, UnspecifiedParsingError
+from eBCSgen.Errors.ComplexParsingError import ComplexParsingError
+from eBCSgen.Errors.UnspecifiedParsingError import UnspecifiedParsingError
 
 
 def load_TS_from_json(json_file: str) -> TransitionSystem:

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -1,7 +1,6 @@
 import collections
 import json
 import numpy as np
-import os
 from numpy import inf
 from copy import deepcopy
 from lark import Lark, Transformer, Tree
@@ -629,8 +628,6 @@ class TreeToObjects(Transformer):
 
 class Parser:
     def __init__(self, start):
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "model_permutation.txt"), "r") as file:
-            model_grammar = file.read()
         grammar = "start: " + start + GRAMMAR + COMPLEX_GRAMMAR + EXTENDED_GRAMMAR + REGULATIONS_GRAMMAR
         self.parser = Lark(grammar, parser='lalr',
                            propagate_positions=False,

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -87,7 +87,8 @@ class SideHelper:
 
 
 GRAMMAR = r"""
-    model: rules (inits)? (definitions)? (complexes)? (regulation)?
+    model: (sections)* rules (sections | rules)*
+    sections: inits | definitions | complexes | regulation
 
     rules: RULES_START _NL+ ((rule|COMMENT) _NL+)* rule _NL*
     inits: INITS_START _NL+ ((init|COMMENT) _NL+)* init _NL*
@@ -174,15 +175,15 @@ REGULATIONS_GRAMMAR = """
 
     !regular: "regular" _NL+ (DIGIT|LETTER| "+" | "*" | "(" | ")" | "[" | "]" | "_" | "|" | "&")+ _NL+
 
-    programmed: "programmed" _NL+ (successors _NL+)+
+    programmed: "programmed" _NL+ (successors _NL+)* successors _NL*
     successors: CNAME ":" "{" CNAME ("," CNAME)* "}"
 
-    ordered: "ordered" _NL+ order ("," order)* _NL+
+    ordered: "ordered" _NL+ order ("," order)* _NL*
     order: ("(" CNAME "," CNAME ")")
 
-    concurrent_free: "concurrent-free" _NL+ order ("," order)* _NL+
+    concurrent_free: "concurrent-free" _NL+ order ("," order)* _NL*
 
-    conditional: "conditional" _NL+ (context _NL+)+
+    conditional: "conditional" _NL+ context (_NL+ context)* _NL*
     context: CNAME ":" "{" rate_complex ("," rate_complex)* "}"
 """
 

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -24,7 +24,7 @@ from eBCSgen.TS.TransitionSystem import TransitionSystem
 from eBCSgen.TS.Edge import edge_from_dict
 from eBCSgen.Core.Side import Side
 from eBCSgen.Core.Model import Model
-from eBCSgen.Errors.ComplexParsingError import ComplexParsingError
+from eBCSgen.Errors import ComplexParsingError, UnspecifiedParsingError
 
 
 def load_TS_from_json(json_file: str) -> TransitionSystem:
@@ -653,6 +653,8 @@ class TreeToObjects(Transformer):
                 if key == "definitions":
                     definitions.update(value)
                 if key == "regulation":
+                    if regulation:
+                        raise UnspecifiedParsingError("Multiple regulations")
                     regulation = value
             elif isinstance(match, Tree) and match.data == "sections":
                 if isinstance(match.children[0], Tree):
@@ -665,6 +667,8 @@ class TreeToObjects(Transformer):
                 if key == "definitions":
                     definitions.update(value)
                 if key == "regulation":
+                    if regulation:
+                        raise UnspecifiedParsingError("Multiple regulations")
                     regulation = value
         params = self.params - set(definitions)
         return Model(rules, inits, definitions, params, regulation)

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -647,30 +647,24 @@ class TreeToObjects(Transformer):
         for match in matches:
             if type(match) == dict:
                 key, value = list(match.items())[0]
-                if key == "rules":
-                    rules.update(value)
-                if key == "inits":
-                    inits.update(value)
-                if key == "definitions":
-                    definitions.update(value)
-                if key == "regulation":
-                    if regulation:
-                        raise UnspecifiedParsingError("Multiple regulations")
-                    regulation = value
             elif isinstance(match, Tree) and match.data == "sections":
                 if isinstance(match.children[0], Tree):
                     continue
                 key, value = list(match.children[0].items())[0]
-                if key == "rules":
-                    rules.update(value)
-                if key == "inits":
-                    inits.update(value)
-                if key == "definitions":
-                    definitions.update(value)
-                if key == "regulation":
-                    if regulation:
-                        raise UnspecifiedParsingError("Multiple regulations")
-                    regulation = value
+            else:
+                continue
+
+            if key == "rules":
+                rules.update(value)
+            elif key == "inits":
+                inits.update(value)
+            elif key == "definitions":
+                definitions.update(value)
+            elif key == "regulation":
+                if regulation:
+                    raise UnspecifiedParsingError("Multiple regulations")
+                regulation = value
+
         params = self.params - set(definitions)
         return Model(rules, inits, definitions, params, regulation)
 

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -89,11 +89,11 @@ class SideHelper:
 GRAMMAR = r"""
     model: rules (inits)? (definitions)? (complexes)? (regulation)?
 
-    rules: RULES_START (rule|COMMENT)+
-    inits: INITS_START (init|COMMENT)+
-    definitions: DEFNS_START (definition|COMMENT)+
-    complexes: COMPLEXES_START (cmplx_dfn|COMMENT)+
-    regulation: REGULATION_START regulation_def
+    rules: RULES_START _NL+ ((rule|COMMENT) _NL+)* rule _NL*
+    inits: INITS_START _NL+ ((init|COMMENT) _NL+)* init _NL*
+    definitions: DEFNS_START _NL+ ((definition|COMMENT) _NL+)* definition _NL*
+    complexes: COMPLEXES_START _NL+ ((cmplx_dfn|COMMENT) _NL+)* cmplx_dfn _NL*
+    regulation: REGULATION_START _NL+ regulation_def _NL*
 
     init: const? rate_complex (COMMENT)?
     definition: def_param "=" number (COMMENT)?
@@ -118,6 +118,7 @@ GRAMMAR = r"""
     DEFNS_START: "#! definitions"
     COMPLEXES_START: "#! complexes"
     REGULATION_START: "#! regulation"
+    _NL: /(\r?\n[\t ]*)+/
 
     !label: CNAME "~"
 
@@ -131,8 +132,9 @@ GRAMMAR = r"""
     %import common.NUMBER
     %import common.INT
     %import common.DECIMAL
-    %import common.WS
-    %ignore WS
+    %import common.WS_INLINE
+    %import common.EOF
+    %ignore WS_INLINE
     %ignore COMMENT
 """
 
@@ -170,17 +172,17 @@ COMPLEX_GRAMMAR = """
 REGULATIONS_GRAMMAR = """
     regulation_def: "type" ( regular | programmed | ordered | concurrent_free | conditional ) 
 
-    !regular: "regular" (DIGIT|LETTER| "+" | "*" | "(" | ")" | "[" | "]" | "_" | "|" | "&")+
+    !regular: "regular" _NL+ (DIGIT|LETTER| "+" | "*" | "(" | ")" | "[" | "]" | "_" | "|" | "&")+ _NL+
 
-    programmed: "programmed" successors+
+    programmed: "programmed" _NL+ (successors _NL+)+
     successors: CNAME ":" "{" CNAME ("," CNAME)* "}"
 
-    ordered: "ordered" order ("," order)*
+    ordered: "ordered" _NL+ order ("," order)* _NL+
     order: ("(" CNAME "," CNAME ")")
 
-    concurrent_free: "concurrent-free" order ("," order)*
+    concurrent_free: "concurrent-free" _NL+ order ("," order)* _NL+
 
-    conditional: "conditional" context+
+    conditional: "conditional" _NL+ (context _NL+)+
     context: CNAME ":" "{" rate_complex ("," rate_complex)* "}"
 """
 

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -173,7 +173,7 @@ COMPLEX_GRAMMAR = """
 REGULATIONS_GRAMMAR = """
     regulation_def: "type" ( regular | programmed | ordered | concurrent_free | conditional ) 
 
-    !regular: "regular" _NL+ (DIGIT|LETTER| "+" | "*" | "(" | ")" | "[" | "]" | "_" | "|" | "&")+ _NL+
+    !regular: "regular" _NL+ (DIGIT|LETTER| "+" | "*" | "(" | ")" | "[" | "]" | "_" | "|" | "&")+ _NL*
 
     programmed: "programmed" _NL+ (successors _NL+)* successors _NL*
     successors: CNAME ":" "{" CNAME ("," CNAME)* "}"


### PR DESCRIPTION
 Order of individual sections (rules, inits, etc) is arbitrary now to allow more flexibility
- rules must be defined at least once
- each section can be defined more than once

Enforcing and accepting newlines:
- ignoring only `WS_INLINE` instead of all `WS`
- specifying where newlines are allowed

Close #93