### PR TITLE
Rule labels in regulations and regular regulations

### DIFF
--- a/Testing/models/regulation5.txt
+++ b/Testing/models/regulation5.txt
@@ -1,3 +1,3 @@
 #! regulation
 type regular
-(r1_Sr1_Tr2|r1_Tr1_Sr2)
+(r1_S;r1_T;r2|r1_T;r1_S;r2)

--- a/eBCSgen/Core/Formula.py
+++ b/eBCSgen/Core/Formula.py
@@ -1,7 +1,7 @@
 from lark import Transformer, Tree
 
 from eBCSgen.Errors.ComplexOutOfScope import ComplexOutOfScope
-from eBCSgen.Core.Rate import tree_to_string
+from eBCSgen.utils import tree_to_string
 
 
 class Formula:

--- a/eBCSgen/Core/Rate.py
+++ b/eBCSgen/Core/Rate.py
@@ -4,6 +4,7 @@ from lark import Transformer, Tree, Token
 from sortedcontainers import SortedList
 
 from eBCSgen.TS.State import Vector
+from eBCSgen.utils import tree_to_string
 
 STATIC_MATH = """<kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><apply>{}</apply></math></kineticLaw>"""
 
@@ -252,15 +253,3 @@ class MathMLtransformer(Transformer):
         operator = self.operators[matches[1].type]
         return Tree(node, [matches[0], Token(matches[1].type, operator), matches[2]])
 
-
-def tree_to_string(tree):
-    """
-    Recursively constructs a list form given lark tree.
-
-    :param tree: given lark tree
-    :return: list of components
-    """
-    if type(tree) == Tree:
-        return sum(list(map(tree_to_string, tree.children)), [])
-    else:
-        return [str(tree)]

--- a/eBCSgen/Errors/RegulationParsingError.py
+++ b/eBCSgen/Errors/RegulationParsingError.py
@@ -1,0 +1,6 @@
+class RegulationParsingError(Exception):
+    def __init__(self, error):
+        self.error = error
+
+    def __str__(self):
+        return "Error while parsing the regulation:\n\n{}".format(self.error)

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -679,9 +679,8 @@ class TreeToObjects(Transformer):
                 if regulation:
                     raise UnspecifiedParsingError("Multiple regulations")
                 # check if regulation is in label
-                if not value.check_labels(self.labels):
-                    raise RegulationParsingError("Regulation label not found")
-                regulation = value
+                if value.check_labels(self.labels):
+                    regulation = value
 
         params = self.params - set(definitions)
         return Model(rules, inits, definitions, params, regulation)

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -189,7 +189,7 @@ COMPLEX_GRAMMAR = """
 REGULATIONS_GRAMMAR = """
     regulation_def: "type" ( regular | programmed | ordered | concurrent_free | conditional ) 
 
-    !regular: "regular" _NL+ (DIGIT|LETTER| "+" | "*" | "(" | ")" | "[" | "]" | "_" | "|" | "&")+ _NL*
+    !regular: "regular" _NL+ (DIGIT|LETTER| "+" | "*" | "(" | ")" | "[" | "]" | "_" | "|" | "&" | ";")+ _NL*
 
     programmed: "programmed" _NL+ (successors _NL+)* successors _NL*
     successors: CNAME ":" "{" CNAME ("," CNAME)* "}"

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -27,6 +27,7 @@ from eBCSgen.Core.Model import Model
 from eBCSgen.Errors.ComplexParsingError import ComplexParsingError
 from eBCSgen.Errors.UnspecifiedParsingError import UnspecifiedParsingError
 from eBCSgen.Errors.RegulationParsingError import RegulationParsingError
+from eBCSgen.utils import tree_to_string
 
 
 def load_TS_from_json(json_file: str) -> TransitionSystem:
@@ -246,23 +247,12 @@ class TransformRegulations(Transformer):
         return matches[0]
 
     def regular(self, matches):
-        re = self.tree_to_regex_string(matches[1])
+        re = "".join(tree_to_string(matches[1]))
         try:
             regex.compile(re)
         except regex.error as e:
             raise RegulationParsingError(f"Invalid regular expression: {re}. Error: {e}")
         return Regular(re)
-    
-    def tree_to_regex_string(self, tree):
-        regex_string = ""
-    
-        if isinstance(tree, Token):
-                return tree.value
-        elif isinstance(tree, Tree):
-            for child in tree.children:
-                regex_string += self.tree_to_regex_string(child)
-                
-        return regex_string
 
     def programmed(self, matches):
         successors = {k: v for x in matches for k, v in x.items()}

--- a/eBCSgen/Regulations/ConcurrentFree.py
+++ b/eBCSgen/Regulations/ConcurrentFree.py
@@ -22,3 +22,10 @@ class ConcurrentFree(BaseRegulation):
             if p_rule and non_p_rule:
                 del candidates[non_p_rule.pop()]
         return candidates
+
+    def check_labels(self, model_labels):
+        for tuple in self.regulation:
+            for label in tuple:
+                if label not in model_labels:
+                    return False
+        return True

--- a/eBCSgen/Regulations/ConcurrentFree.py
+++ b/eBCSgen/Regulations/ConcurrentFree.py
@@ -1,3 +1,4 @@
+from eBCSgen.Errors.RegulationParsingError import RegulationParsingError
 from eBCSgen.Regulations.Base import BaseRegulation
 
 
@@ -27,5 +28,5 @@ class ConcurrentFree(BaseRegulation):
         for tuple in self.regulation:
             for label in tuple:
                 if label not in model_labels:
-                    return False
+                    raise RegulationParsingError(f"Label {label} in concurrent-free regulation not present in model")
         return True

--- a/eBCSgen/Regulations/Conditional.py
+++ b/eBCSgen/Regulations/Conditional.py
@@ -19,6 +19,12 @@ class Conditional(BaseRegulation):
     def filter(self, current_state, candidates):
         agents = set(current_state.content.value)
         return {rule: values for rule, values in candidates.items() if not self.check_intersection(rule.label, agents)}
+    
+    def check_labels(self, model_labels):
+        for label in self.regulation:
+            if label not in model_labels:
+                return False
+        return True
 
     def check_intersection(self, label, agents):
         if label not in self.regulation:

--- a/eBCSgen/Regulations/Conditional.py
+++ b/eBCSgen/Regulations/Conditional.py
@@ -1,3 +1,4 @@
+from eBCSgen.Errors.RegulationParsingError import RegulationParsingError
 from eBCSgen.Regulations.Base import BaseRegulation
 
 
@@ -23,7 +24,7 @@ class Conditional(BaseRegulation):
     def check_labels(self, model_labels):
         for label in self.regulation:
             if label not in model_labels:
-                return False
+                raise RegulationParsingError(f"Label {label} in conditional regulation not present in model")
         return True
 
     def check_intersection(self, label, agents):

--- a/eBCSgen/Regulations/Ordered.py
+++ b/eBCSgen/Regulations/Ordered.py
@@ -1,3 +1,4 @@
+from eBCSgen.Errors.RegulationParsingError import RegulationParsingError
 from eBCSgen.Regulations.Base import BaseRegulation
 
 
@@ -43,5 +44,5 @@ class Ordered(BaseRegulation):
         for tuple in self.regulation:
             for label in tuple:
                 if label not in model_labels:
-                    return False
+                    raise RegulationParsingError(f"Label {label} in programmed regulation not present in model")
         return True

--- a/eBCSgen/Regulations/Ordered.py
+++ b/eBCSgen/Regulations/Ordered.py
@@ -38,3 +38,10 @@ class Ordered(BaseRegulation):
             return candidates
         last_rule = current_state.memory.history[-1]
         return {rule: values for rule, values in candidates.items() if not (last_rule, rule.label) in self.regulation}
+    
+    def check_labels(self, model_labels):
+        for tuple in self.regulation:
+            for label in tuple:
+                if label not in model_labels:
+                    return False
+        return True

--- a/eBCSgen/Regulations/Programmed.py
+++ b/eBCSgen/Regulations/Programmed.py
@@ -26,9 +26,9 @@ class Programmed(BaseRegulation):
         return candidates
     
     def check_labels(self, model_labels):
-        for key, value in self.regulation.items():
-            if key not in model_labels:
+        for rule_label, successors_labels in self.regulation.items():
+            if rule_label not in model_labels:
                 return False
-            if value > model_labels:
+            if not successors_labels.issubset(model_labels):
                 return False
         return True

--- a/eBCSgen/Regulations/Programmed.py
+++ b/eBCSgen/Regulations/Programmed.py
@@ -1,3 +1,4 @@
+from eBCSgen.Errors.RegulationParsingError import RegulationParsingError
 from eBCSgen.Regulations.Base import BaseRegulation
 
 
@@ -28,7 +29,8 @@ class Programmed(BaseRegulation):
     def check_labels(self, model_labels):
         for rule_label, successors_labels in self.regulation.items():
             if rule_label not in model_labels:
-                return False
+                raise RegulationParsingError(f"Label {rule_label} in programmed regulation not present in model")
             if not successors_labels.issubset(model_labels):
-                return False
+                missing_labels = successors_labels - model_labels
+                raise RegulationParsingError(f"Label(s) {missing_labels} in programmed regulation not present in model")
         return True

--- a/eBCSgen/Regulations/Programmed.py
+++ b/eBCSgen/Regulations/Programmed.py
@@ -24,3 +24,11 @@ class Programmed(BaseRegulation):
         if last_rule in self.regulation:
             return {rule: values for rule, values in candidates.items() if rule.label in self.regulation[last_rule]}
         return candidates
+    
+    def check_labels(self, model_labels):
+        for key, value in self.regulation.items():
+            if key not in model_labels:
+                return False
+            if value > model_labels:
+                return False
+        return True

--- a/eBCSgen/Regulations/Regular.py
+++ b/eBCSgen/Regulations/Regular.py
@@ -1,5 +1,6 @@
 import regex
 from itertools import permutations
+from eBCSgen.Errors.RegulationParsingError import RegulationParsingError
 
 from eBCSgen.Regulations.Base import BaseRegulation
 
@@ -34,5 +35,5 @@ class Regular(BaseRegulation):
             subregex = regex.compile(pattern)
             if any(subregex.search(p) for p in all_permutations):
                 continue
-            return False
+            raise RegulationParsingError(f"Label in programmed regulation not present in model")
         return True

--- a/eBCSgen/Regulations/Regular.py
+++ b/eBCSgen/Regulations/Regular.py
@@ -23,3 +23,17 @@ class Regular(BaseRegulation):
         path = "".join(current_state.memory.history)
         return {rule: values for rule, values in candidates.items()
                 if self.regulation.fullmatch(path + rule.label, partial=True) is not None}
+    
+    def check_labels(self, model_labels):
+        positions = [False] * len(self.regulation.pattern)
+        for label in model_labels:
+            match = regex.search(label, self.regulation.pattern)
+            while match is not None:
+                for i in range(match.start(), match.end()):
+                    positions[i] = True
+                match = regex.search(label, self.regulation.pattern, pos=match.end())
+
+        for i, position in enumerate(positions):
+            if not position and self.regulation.pattern[i] not in ".*+?^${}()[]|\\":
+                return False
+        return True

--- a/eBCSgen/Regulations/Regular.py
+++ b/eBCSgen/Regulations/Regular.py
@@ -1,5 +1,4 @@
 import regex
-from itertools import permutations
 from eBCSgen.Errors.RegulationParsingError import RegulationParsingError
 
 from eBCSgen.Regulations.Base import BaseRegulation
@@ -27,13 +26,16 @@ class Regular(BaseRegulation):
                 if self.regulation.fullmatch(path + rule.label, partial=True) is not None}
     
     def check_labels(self, model_labels):
-        patterns = self.regulation.pattern[1:-1].split('|')
-        # Generate all permutations of the label in the set
-        all_permutations = [''.join(p) for i in range(len(model_labels)) for p in permutations(model_labels, i+1)]
-        # Check if the regex matches any permutation
+        patterns = self.regulation.pattern[1:-1].split("|")
+        subpaterns_set = set()
         for pattern in patterns:
-            subregex = regex.compile(pattern)
-            if any(subregex.search(p) for p in all_permutations):
+            subpaterns_set = subpaterns_set.union(set(pattern.split(";")))
+
+        for subpattern in subpaterns_set:
+            subregex = regex.compile(subpattern)
+            if any(subregex.search(label) for label in model_labels):
                 continue
-            raise RegulationParsingError(f"Label in programmed regulation not present in model")
+            raise RegulationParsingError(
+                f"Label in programmed regulation not present in model"
+            )
         return True

--- a/eBCSgen/Regulations/Regular.py
+++ b/eBCSgen/Regulations/Regular.py
@@ -26,7 +26,7 @@ class Regular(BaseRegulation):
                 if self.regulation.fullmatch(path + rule.label, partial=True) is not None}
     
     def check_labels(self, model_labels):
-        patterns = self.regulation.pattern[1:-1].split("|")
+        patterns = self.regulation.pattern.replace("(", "").replace(")", "").split("|")
         subpaterns_set = set()
         for pattern in patterns:
             subpaterns_set = subpaterns_set.union(set(pattern.split(";")))

--- a/eBCSgen/Regulations/Regular.py
+++ b/eBCSgen/Regulations/Regular.py
@@ -1,4 +1,5 @@
 import regex
+from itertools import permutations
 
 from eBCSgen.Regulations.Base import BaseRegulation
 
@@ -25,15 +26,13 @@ class Regular(BaseRegulation):
                 if self.regulation.fullmatch(path + rule.label, partial=True) is not None}
     
     def check_labels(self, model_labels):
-        positions = [False] * len(self.regulation.pattern)
-        for label in model_labels:
-            match = regex.search(label, self.regulation.pattern)
-            while match is not None:
-                for i in range(match.start(), match.end()):
-                    positions[i] = True
-                match = regex.search(label, self.regulation.pattern, pos=match.end())
-
-        for i, position in enumerate(positions):
-            if not position and self.regulation.pattern[i] not in ".*+?^${}()[]|\\":
-                return False
+        patterns = self.regulation.pattern[1:-1].split('|')
+        # Generate all permutations of the label in the set
+        all_permutations = [''.join(p) for i in range(len(model_labels)) for p in permutations(model_labels, i+1)]
+        # Check if the regex matches any permutation
+        for pattern in patterns:
+            subregex = regex.compile(pattern)
+            if any(subregex.search(p) for p in all_permutations):
+                continue
+            return False
         return True

--- a/eBCSgen/utils.py
+++ b/eBCSgen/utils.py
@@ -1,0 +1,14 @@
+from lark import Tree
+
+
+def tree_to_string(tree):
+    """
+    Recursively constructs a list form given lark tree.
+
+    :param tree: given lark tree
+    :return: list of components
+    """
+    if type(tree) == Tree:
+        return sum(list(map(tree_to_string, tree.children)), [])
+    else:
+        return [str(tree)]


### PR DESCRIPTION
This pull request is ensuring all rule labels referenced in regulations exist within the model and makes sure that only correct regular expressions are allowed in regular regulation. 

Invalid regulations now trigger new error `RegulationParsingError`.

Each regulation has now a method `check_labels` that makes sure labels mentioned in the regulation actually exist in the model.

Close #95
Close #88