### PR TITLE
Robust rate expressions

### DIFF
--- a/Testing/parsing/test_rate.py
+++ b/Testing/parsing/test_rate.py
@@ -64,3 +64,34 @@ def test_parser():
     # nested complexes
     ret = objects.rate_parser.parse("[K([L()::cell])::cyt]")
     assert not ret.success
+
+    # nested parenthesis
+    assert objects.rate_parser.parse("(2 * (3 + 4)) / (5 - (6 * 7))").success
+    assert objects.rate_parser.parse("((2 + 3) * (4 - 5)) / ((6 * 7) + 8)").success
+
+    # complex mathematical operations
+    assert objects.rate_parser.parse("2 * [A()::cyt] + 3 / [B(T{s})::cell]").success
+    assert objects.rate_parser.parse("[X()::cyt] ** 2 - (4 * [Y()::cell])").success
+
+    # multiple level nesting
+    assert objects.rate_parser.parse("((2 * [A()::cyt]) + (3 / [B(T{s})::cell])) / ((4 * [C()::cell]) - (2 * [D()::cyt]))").success
+    assert objects.rate_parser.parse("([X()::cyt] ** 2) / ([Y()::cell] + ([Z()::cyt] * 3))").success
+
+    # complex rate_agents
+    assert objects.rate_parser.parse("[A().B()::cyt] + [C().D()::nuc]").success
+    assert objects.rate_parser.parse("[X(Y{a}).Z(W{b})::cell]").success
+    assert objects.rate_parser.parse("2 * [A()::cyt] + [B(T{s})::cell] ** 3").success
+    assert objects.rate_parser.parse("[X()::cyt] / ([Y{a}::cell] + [Z{b}::cyt])").success
+
+    # invalid syntax
+    assert not objects.rate_parser.parse("2 * [A()::cyt] + 3 / [B(T{s})::cell] +").success # extra +
+    assert not objects.rate_parser.parse("[A().B()::cyt] + C().D()::nuc]").success # missing [
+    assert not objects.rate_parser.parse("[X(Y{a}).Z(W{b})::cell").success # missing ]
+    assert not objects.rate_parser.parse("2 * [A()::cyt] + [B(T{s})::cell * 3").success # missing ]
+    assert not objects.rate_parser.parse("[X()::cyt] ** 2 - (4 * [Y()::cell]))").success # extra )
+    assert not objects.rate_parser.parse("2 & [A()::cyt] + 3 | [B(T{s})::cell]").success # invalid operators
+    assert not objects.rate_parser.parse("2 ** [X()::cyt]").success # invalid operation - exponentiation
+    assert not objects.rate_parser.parse("2 * K()::cyt").success # missing required brackets for rate agent
+    assert not objects.rate_parser.parse("[X()::cyt] ** 2 - 4 * Y()::cell").success # missing required brackets for rate agent
+    assert not objects.rate_parser.parse("[X()::cyt] / {Y} + [Z()::cell]").success
+    assert not objects.rate_parser.parse("[K([L()::cell])::cyt] + [A(B(C{d})).D(E{e}::cyt)]").success # nested rate agents and incorrect syntax

--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -120,8 +120,8 @@ GRAMMAR = r"""
     side: (const? complex "+")* (const? complex)?
     complex: (abstract_sequence|value|cmplx_name) DOUBLE_COLON compartment
 
-    !rate : fun "/" fun | fun
-    !fun: const | param | rate_agent | fun "+" fun | fun "-" fun | fun "*" fun | fun POW const | "(" fun ")"
+    !rate : fun
+    !fun: const | param | rate_agent | fun "+" fun | fun "-" fun | fun "*" fun | fun POW const | "(" fun ")" | fun "/" fun
 
     !rate_agent: "[" rate_complex "]"
 


### PR DESCRIPTION
This update addresses issue #87, which highlighted the limitations in representing complex rational expressions. Previously, the grammar supported only basic rational expressions without the capability for nesting divisions.

Only a small change has been made, by moving the `fun "/" fun` rule from being an exclusive part of the `!rate` rule to being incorporated within the `!fun` rule itself construction of more complex fractions and rational expressions is enabled. 

Extensive tests have been added to cover the new grammar capabilities, ensuring that nested divisions are handled correctly and that the change does not introduce any regressions.