### PR TITLE
error raised when alias in rule is not defined

### DIFF
--- a/eBCSgen/Parsing/ParseBCSL.py
+++ b/eBCSgen/Parsing/ParseBCSL.py
@@ -362,6 +362,10 @@ class TransformAbstractSyntax(Transformer):
         self.complex_defns = complex_defns
 
     def cmplx_name(self, matches):
+        if str(matches[0]) not in self.complex_defns:
+            raise ComplexParsingError(
+                f"Complex alias {matches[0]} not found in defined complexes: {list(self.complex_defns.keys())}", matches
+            )
         return deepcopy(self.complex_defns[str(matches[0])])
 
     def abstract_sequence(self, matches):


### PR DESCRIPTION
Checking if complex alias used in rules is defined and raising `ComplexParsingError` if not.

Incorrect tests were corrected and new tests targeting this issue were added.

This pull request closes #103.